### PR TITLE
New aggregate method

### DIFF
--- a/MongoAdapter.js
+++ b/MongoAdapter.js
@@ -120,7 +120,14 @@ module.exports = (function() {
         });
       }, dbs[collectionName], cb);
     },
-
+    aggregate: function(collectionName, pipeline, cb) {
+        spawnConnection(function(connection, cb) {
+            var collection = connection.collection(collectionName);
+            collection.aggregate(pipeline, function(err, result) {
+                cb(err, rewriteIds(result));
+            });
+        }, dbs[collectionName], cb);
+    },
     identity: 'sails-mongo'
   };
 


### PR DESCRIPTION
Added aggregate method to use Aggregate functions in modules
Usage: Model.aggregate([{$group:{field1:"$email",totalEmails:{$sum:1}}}],function(err,docs){});
More info on Aggregate functions: http://mongodb.github.com/node-mongodb-native/api-generated/collection.html#aggregate
