### PR TITLE
fix: avoid parsing a regular number to date

### DIFF
--- a/MongoAdapter.js
+++ b/MongoAdapter.js
@@ -192,6 +192,8 @@ module.exports = (function() {
         obj[key] = false;
       else if (val === "true")
         obj[key] = true;
+      else if (!_.isNaN(val))
+        obj[key] = val;
       else if (!_.isNaN(Date.parse(val)))
         obj[key] = new Date(val);
       else if (_.isObject(val))


### PR DESCRIPTION
In the current codes, basically converts every number into a date object for I don't know what reason. Problem is, things are screwing up badly if the user try to use $gt, $gte, $lt and $lte comparisons. 
