### PR TITLE
Add support for Mongo-CR authenticated connections

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -28,6 +28,8 @@ module.exports = (function() {
       host: 'localhost',
       database: 'sails',
       port: 27017,
+      user: null,
+      password: null,
       schema: false,
       nativeParser: false,
       safe: true
@@ -339,12 +341,23 @@ module.exports = (function() {
   }
 
   function createConnection(config, cb) {
-    var server = new Server(config.host, config.port, {native_parser: config.nativeParser});
+    var server = new Server(config.host, config.port, {native_parser: config.nativeParser, auth: { user: config.user, password: config.password }});
     var db = new Db(config.database, server, {safe: config.safe, native_parser: config.nativeParser});
 
     db.open(function(err) {
-      if (err) return cb(err);
-      cb(null, db);
+      if (err) cb(err);
+      if (db.serverConfig.options.auth.user && db.serverConfig.options.auth.password) {
+        db.authenticate(db.serverConfig.options.auth.user, db.serverConfig.options.auth.password, function(err, success) {
+          if (success){
+            cb(null, db);
+          } else {
+            if (db) db.close();
+            cb(err ? err : new Error('Could not authenticate user ' + auth[0]), null);
+          }
+        });
+      } else {
+        cb(null, db);
+      }
     });
   }
 


### PR DESCRIPTION
Addresses issue #32. Also, enables Sails usage with remote Mongo hosting services such as MongoLab and MongoHQ.

Signed-off-by: Max Fierke max@maxfierke.com
