### PR TITLE
"Cannot read property 'limit' of null"

### DIFF
--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -237,8 +237,10 @@ module.exports = {
       };
 
       // Kick off parsing
-      recursiveParse(original);
-      query[key] = original;
+      if (original){
+          recursiveParse(original);
+          query[key] = original;
+      }
     });
 
     return query;


### PR DESCRIPTION
I'm encountering this problem all the time, even with the most recent version of sails-mongo.  The fix is easy.
