### PR TITLE
Using 'not' or '!' criteria causes MongoError

### DIFF
--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -77,7 +77,7 @@ module.exports = {
     _.each(obj, function(val, key) {
 
       // TODO: do for all types
-      // Parse type based on attibute type.
+      // Parse type based on attribute type.
       // NOTE: MAKE THIS PART OF WATERLINE EVENTUALLY
       if (schema && schema[key] && schema[key].type === 'datetime') {
         if (!_.isNaN(Date.parse(val))) {
@@ -127,7 +127,7 @@ module.exports = {
           Object.keys(obj).forEach(function(criteria) {
             var val;
 
-            // Recursivly Parse
+            // Recursively Parse
             if(_.isObject(obj[criteria]) && !(obj[criteria] instanceof Date)) {
               parent = criteria;
               recursiveParse(obj[criteria]);
@@ -215,6 +215,7 @@ module.exports = {
               val = obj[criteria];
               delete original[parent];
               original[parent] = { '$ne': val };
+              return;
             }
 
             // Ignore special attributes


### PR DESCRIPTION
I'm getting the following error when trying to use the 'not' or '!' criteria: 

[MongoError: invalid regular expression operator] name: 'MongoError'

This simple fix worked for me:
Add missing return statement to the if block that adds 'not' criteria.
