### PR TITLE
Add count method to adapter

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -166,6 +166,18 @@ module.exports = (function() {
       }
     },
 
+    count: function(collectionName, options, cb) {
+      spawnConnection(function(connection, cb) {
+        connection.collection(collectionName, function(err, collection) {
+          if (err) return cb(err);
+          collection.count(options, function(err, count) {
+            if (err) return cb(err);
+            cb(null, count);
+          });
+        });
+      }, dbs[collectionName].config, cb);
+    },
+
     create: function(collectionName, data, cb) {
       spawnConnection(function(connection, cb) {
         connection.collection(collectionName, function(err, collection) {


### PR DESCRIPTION
There wasn't a count method for the Mongo adapter, so in the count method in node_modules/sails/node_modules/waterline/lib/waterline/query/dql.js it falls back to running the find method and then getting the length. On my large dataset this didn't even seem to be working, so I discovered this issue and added a count method to the Mongo adapter.
