### PR TITLE
Enable find by missing or null fields

### DIFF
--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -89,6 +89,8 @@ module.exports = {
         obj[key] = false;
       else if (val === "true")
         obj[key] = true;
+      else if (val === "null")
+        obj[key] = null;
       else if (_.isNumber(val))
         obj[key] = obj[key];
       else if (key == 'or') {


### PR DESCRIPTION
Will return result if the field is either not present in a record, or
present with a value of null, but not “null”.
