### PR TITLE
Associations: fix to be able to use options in find like limit, skip, ...

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -205,7 +205,7 @@ Query.prototype.parseOptions = function parseOptions(key, obj, original, parent)
       val;
 
   // Just case insensitive regex a string unless it's a mongo id
-  if(!_.isPlainObject(obj)) {
+  if(obj !== null && !_.isPlainObject(obj)) {
 
     // Check for Mongo IDs
     if(hasOwnProperty(obj, key) && utils.matchMongoId(obj[key])) {


### PR DESCRIPTION
I was unable to use limit, skip, sort as options in a find() query, because obj was null sometimes. This simple null check fixed it for me and hopefully also for the rest of the world.
