### PR TITLE
Regexp flag causing issue with line break

### DIFF
--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -123,7 +123,7 @@ module.exports = {
             if(_.isObject(obj[key]) && !(obj[key] instanceof Date)) {
               obj[key] = recursiveParse2(obj[key]);
             }
-            
+
             // Handle Sorting Order with binary or -1/1 values
             if(key === 'sort') {
               obj[key] = ([0, -1].indexOf(obj[key]) > -1) ? -1 : 1;
@@ -131,7 +131,7 @@ module.exports = {
 
             if (key === 'contains') {
               obj = '.*' + utils.caseInsensitive(obj[key]) + '.*';
-              obj = new RegExp('^' + obj + '$', 'i');
+              obj = new RegExp('^' + obj + '$', 'ig');
             }
 
             if(key === 'like') {
@@ -178,7 +178,7 @@ module.exports = {
               if(typeof obj[key] === 'string') {
                 obj[key] = utils.caseInsensitive(obj[key]);
                 obj[key] = obj[key].replace(/%/g, '.*');
-                obj[key] = new RegExp('^' + obj[key] + '$', 'i');
+                obj[key] = new RegExp('^' + obj[key] + '$', 'ig');
               }
             }
 


### PR DESCRIPTION
Hi everyone,

I added the g flag to the regular expression used for any **where request** using the **contains** or **like** attribute.

When doing a request like the following one. Assuming a long text containing line breaks is defined for each content field, this doesn't work. Without my fix, this only works if the field doesn't contain any line break (\n).

``` javascript
var q = req.param('query');
Post.find({
  content: {
    contains: q
  }
}, function (err, posts) {
  if (err) { return res.view('index', {posts: {}}); }
  return res.view({posts: posts});
});
```

Cheers.
