### PR TITLE
limit db  connection only one as expection

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -483,7 +483,6 @@ module.exports = (function() {
     connecting = true;
     //when db connection result events
     eventer.once( 'dbConnectResult', function( err ) {
-        console.log( cbStacks.length );
         cbStacks.forEach( function( cb ) {
             afterwards( cb );
         });

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -20,7 +20,12 @@ module.exports = (function() {
       schemaStash = {};
 
   // Holds an open connection
-  var connection = {};
+  var connection = {}
+  ,   connecting = false
+  ,   cbStacks   = [];
+
+  var eventer = new (require('events').EventEmitter)();
+
 
   var adapter = {
     syncable: true, // to track schema internally
@@ -462,16 +467,31 @@ module.exports = (function() {
 
     // Grab the existing connection
     if(Object.keys(connection).length > 0) {
-      return afterwards();
+      return afterwards( cb );
     }
-
+    if( connecting == true ) {
+        //push callback into stacks
+        cbStacks.push( cb );
+        return;
+    }
     createConnection(config, function(err, db) {
       if(err) console.log(err);
       connection = db;
-      afterwards();
+      eventer.emit( 'dbConnectResult', err );
+      afterwards( cb );
+    });
+    connecting = true;
+    //when db connection result events
+    eventer.once( 'dbConnectResult', function( err ) {
+        console.log( cbStacks.length );
+        cbStacks.forEach( function( cb ) {
+            afterwards( cb );
+        });
+        cbStacks = [];
+        connecting = false;
     });
 
-    function afterwards() {
+    function afterwards( cb ) {
       logic(connection, function(err, result) {
         if(cb) return cb(err, result);
       });

--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -182,9 +182,9 @@ module.exports = {
             if(['_bsontype', '_id', 'id'].indexOf(key) == -1) {
               // Replace Percent Signs
               if(typeof obj[key] === 'string') {
-                obj[key] = utils.caseInsensitive(obj[key]);
-                obj[key] = obj[key].replace(/%/g, '.*');
                 //regexp too slow
+                //obj[key] = utils.caseInsensitive(obj[key]);
+                //obj[key] = obj[key].replace(/%/g, '.*');
                 //obj[key] = new RegExp('^' + obj[key] + '$', 'ig');
               }
             }

--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -184,7 +184,8 @@ module.exports = {
               if(typeof obj[key] === 'string') {
                 obj[key] = utils.caseInsensitive(obj[key]);
                 obj[key] = obj[key].replace(/%/g, '.*');
-                obj[key] = new RegExp('^' + obj[key] + '$', 'ig');
+                //regexp too slow
+                //obj[key] = new RegExp('^' + obj[key] + '$', 'ig');
               }
             }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "async": "0.2.10",
     "underscore": "1.5.2",
     "underscore.string": "2.3.3",
-    "mongodb": "~1.3.23"
+    "mongodb": "~1.4.2"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
 I've found sails-mongo make many db connections when sails lift. After  took a short experiment, I dig out the problem is that waterline make async call each model's define initial. Async execute every item concurrently, so the connection varialbe switch lost the limit function.

To resolve the issue, I've introduced an eventer into spawnConnection function.