### PR TITLE
TypeError: Object.keys called on non-object

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -297,7 +297,7 @@ module.exports = (function() {
      */
 
     update: function(connectionName, collectionName, options, values, cb) {
-	  options = options || {};
+      options = options || {};
       var connectionObject = connections[connectionName];
       var collection = connectionObject.collections[collectionName];
 
@@ -320,8 +320,8 @@ module.exports = (function() {
      */
 
     destroy: function(connectionName, collectionName, options, cb) {
-	  options = options || {};
-	  var connectionObject = connections[connectionName];
+      options = options || {};
+      var connectionObject = connections[connectionName];
       var collection = connectionObject.collections[collectionName];
 
       // Find matching documents
@@ -348,7 +348,7 @@ module.exports = (function() {
      */
 
     count: function(connectionName, collectionName, options, cb) {
-	  options = options || {};
+      options = options || {};
       var connectionObject = connections[connectionName];
       var collection = connectionObject.collections[collectionName];
 


### PR DESCRIPTION
Work around for https://github.com/balderdashy/sails-mongo/issues/147
