### PR TITLE
Support embeddable association (denormalization)

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -97,9 +97,28 @@ Document.prototype.serializeValues = function serializeValues(values) {
 
     var foreignKey = self.schema[key].foreignKey || false;
 
-    // If a foreignKey, check if value matches a mongo id and if so turn it into an objectId
-    if(foreignKey && utils.matchMongoId(values[key])) {
-      values[key] = new ObjectId.createFromHexString(values[key]);
+    var embed = self.schema[key].embed || false;
+
+    var on = self.schema[key].on || 'id';
+
+    // If a foreignKey, check if there is value matching a mongo id and if so turn it into an objectId
+    if(foreignKey) {
+      // Is it a sub-document or not
+      if(!_.isPlainObject(values[key])) {
+        // If value is NOT a sub-document, check if value matches a mongo id and
+        // if so turn it into an objectId
+        if(utils.matchMongoId(values[key])) {
+          values[key] = new ObjectId.createFromHexString(values[key]);
+        }
+      } else {
+        // If value is a sub-document and this association is set to embeddable,
+        // check if the embedded sub-document has a pk that matches a mongo id
+        // and if so turn it into an objectId
+        if(embed && values[key] && utils.matchMongoId(values[key][on])) {
+          values[key]._id = new ObjectId.createFromHexString(values[key][on]);
+          delete values[key].id;
+        }
+      }
     }
 
     if(type === 'json') {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,6 +51,17 @@ exports.rewriteIds = function rewriteIds(models, schema) {
       if(foreignKey && model[key] instanceof ObjectId) {
         model[key] = model[key].toString();
       }
+
+      var embed = schema[key].embed || false;
+
+      // If a foreignKey that embeddable, check if there is an embedded
+      // sub-document that has an `_id` property with type of ObjectId and if so
+      // turn it into a normalized id atrribute
+      if (foreignKey && embed && _.isPlainObject(model[key])
+        && hop.call(model[key], '_id') && model[key]._id instanceof ObjectId) {
+        model[key].id = model[key]._id.toString();
+        delete model[key]._id;
+      }
     });
 
     return model;


### PR DESCRIPTION
Need certain commits in `waterline` and `waterline-schema`, association
can be set to embeddable using `embed` keyword. And if so, the
associating model can be fully or partially embedded. This is
denormalization.

https://github.com/balderdashy/waterline/issues/427