### PR TITLE
support criteria on id field, convert them all to ObjectId

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -94,14 +94,19 @@ Query.prototype.normalizeWhereId = function normalizeWhereId(options) {
     }
 
     // If we have an object, assume this is a criteria on `_id` field.
-    if(_.isPlainObject(options.where['_id'])) {
-      options.where['_id'] = _.mapValues(options.where['_id'], function (id) {
+    else if(_.isPlainObject(options.where['_id'])) {
+      options.where['_id'] = _.mapValues(options.where['_id'], function (val) {
         "use strict";
-        return utils.matchMongoId(id.toString()) ? new ObjectId(id.toString()) : id;
+        if (_.isArray(val)) {
+          return _.map(val, function(id) {
+            return utils.matchMongoId(id.toString()) ? new ObjectId(id.toString()) : id;
+          });
+        }
+        return utils.matchMongoId(val.toString()) ? new ObjectId(val.toString()) : val;
       });
     }
 
-    if(utils.matchMongoId(options.where['_id'])) {
+    else if(utils.matchMongoId(options.where['_id'])) {
       options.where['_id'] = new ObjectId(options.where['_id'].toString());
     }
   }


### PR DESCRIPTION
`where={ id: { '>': '51e866e48737f72b32ae4fbc' } }` This should work now. Support for '>', '>=', '<', '<='. Very useful for pagination on range query.

This PR only works for id field (`_id`), not any other field with type of `objectid`(like association field).
