### PR TITLE
support sort by id, normalize id to _id.

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -313,6 +313,13 @@ Query.prototype.parseOptions = function parseOptions(key, obj, original, parent)
     // Handle Sorting Order with binary or -1/1 values
     if(key === 'sort') {
       original[attr] = ([0, -1].indexOf(obj[attr]) > -1) ? -1 : 1;
+
+      // Normalize id, if used, into _id
+      if (attr === 'id') {
+        original['_id'] = original[attr];
+        delete original[attr];
+      }
+      return;
     }
 
     // Handle `contains` by building up a case insensitive regex


### PR DESCRIPTION
`sort='id desc'` should work now.
