### PR TITLE
Add query option 'field' to support specifing return field.

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -90,10 +90,11 @@ Collection.prototype.find = function find(criteria, cb) {
   }
 
   var where = query.criteria.where || {};
-  var queryOptions = _.omit(query.criteria, 'where');
-
+  var queryOptions = _.omit(query.criteria, ['where','field']);
+  var field = query.criteria.field
+  var args = field === undefined ? [where, queryOptions] : [where,field,queryOptions]
   // Run Normal Query on collection
-  collection.find(where, queryOptions).toArray(function(err, docs) {
+  collection.find.apply(collection, args).toArray(function(err, docs) {
     if(err) return cb(err);
     cb(null, utils.rewriteIds(docs, self.schema));
   });


### PR DESCRIPTION
Almost every database support query option ‘field’ to specify what field you want from returned data. It is very useful when you want to skip large data field to make query faster.