### PR TITLE
KeepAlive should be a number.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -55,7 +55,7 @@ module.exports = (function() {
       poolSize: 1,
       socketOptions: {
         noDelay: false,
-        keepAlive: true,
+        keepAlive: 0,
         connectTimeoutMS: 5000,
         socketTimeoutMS: 5000
       },


### PR DESCRIPTION
According to these docs:
http://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html#server-a-hash-of-options-at-the-server-level-not-supported-by-the-url
http://nodejs.org/api/net.html#net_socket_setkeepalive_enable_initialdelay
KeepAlive should be a number.
