### PR TITLE
Issue: #190.

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -316,20 +316,27 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
     // certain values into booleans or null.  Otherwise they'll be left
     // as strings.
     if (hop(self.schema, field) && self.schema[field].type != 'string') {
+
       if(self.schema[field].type === 'integer'){
         return parseInt(val);
-      }else if(self.schema[field].type === 'float'){
+      }
+
+      if(self.schema[field].type === 'float'){
         return parseFloat(val);
-      }else{
-        if (val === "false") {
-          return false;
-        }
-        if (val === "true") {
-          return true;
-        }
-        if (val === "null") {
-          return null;
-        }
+      }
+
+      if (val === "false") {
+        return false;
+      }
+
+      if (val === "true") {
+        return true;
+      }
+
+      if (val === "null") {
+        return null;
+      }
+
     }
 
     if(modifier === '$ne') {


### PR DESCRIPTION
Given a model with non string attributes, blueprint queries of the form http://somedomain.com/model/?price=12313 were not working, as the value 12313 was being treated as a string, and turned into a regex by this adapter within the query/index.js `parseValue` function. 

I added a check on the schama type within the definition of `parseValue`. If the type is a integer or float, I return the converted value. 
