### PR TITLE
Fix #159: Restore .stream() to adapter

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -423,6 +423,25 @@ module.exports = (function() {
 
     },
 
+    /**
+     * Stream
+     *
+     * Stream one or more documents from the collection
+     * using where, limit, skip, and order
+     * In where: handle `or`, `and`, and `like` queries
+     *
+     * @param {String} connectionName
+     * @param {String} collectionName
+     * @param {Object} options
+     * @param {Object} stream
+     */
+    stream: function(connectionName, collectionName, options, stream) {
+      options = options || {};
+      var connectionObject = connections[connectionName];
+      var collection = connectionObject.collections[collectionName];
+
+      collection.stream(options, stream);
+    },
 
     identity: 'sails-mongo'
   };

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -105,6 +105,61 @@ Collection.prototype.find = function find(criteria, cb) {
 };
 
 /**
+ * Stream Documents
+ *
+ * @param {Object} criteria
+ * @param {Object} stream
+ * @api public
+ */
+Collection.prototype.stream = function find(criteria, stream) {
+  var self = this,
+    query;
+
+  // Ignore `select` from waterline core
+  if (typeof criteria === 'object') {
+    delete criteria.select;
+  }
+
+  // Catch errors from building query and return to the callback
+  try {
+    query = new Query(criteria, this.schema);
+  } catch(err) {
+    return stream.end(err); // End stream
+  }
+
+  var collection = this.connection.db.collection(self.identity);
+
+  var where = query.criteria.where || {};
+  var queryOptions = _.omit(query.criteria, 'where');
+
+  // Run Normal Query on collection
+  var dbStream = collection.find(where, queryOptions).stream();
+
+  // For each data item
+  dbStream.on('data', function(item) {
+    // Pause stream
+    dbStream.pause();
+
+    var obj = utils.rewriteIds([item], self.schema)[0];
+
+    stream.write(obj, function() {
+      dbStream.resume();
+    });
+
+  });
+
+  // Handle error, an 'end' event will be emitted after this as well
+  dbStream.on('error', function(err) {
+    stream.end(err); // End stream
+  });
+
+  // all rows have been received
+  dbStream.on('close', function() {
+    stream.end();
+  });
+};
+
+/**
  * Insert A New Document
  *
  * @param {Object|Array} values


### PR DESCRIPTION
Brings back the stream method that was lost from 0.9.x.

Fixes: #159.
