### PR TITLE
Support for uri_decode_auth in MongoClient connections

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -117,6 +117,9 @@ Connection.prototype._buildConnection = function _buildConnection(cb) {
     numberOfRetries: this.config.numerOfRetries
   };
 
+  // Support for encoded auth credentials
+  connectionOptions.uri_decode_auth = this.config.uri_decode_auth || false;
+
   // Build A Mongo Connection String
   var connectionString = 'mongodb://';
 


### PR DESCRIPTION
Adds support for encoded usernames and passwords in config.connections objects. Add `uri_decode_auth: true` to your connection to enable.

example: **config/env/development.js**

``` javascript
module.exports = {

  models: {
    connection: 'mongoDb'
  },

  connections: {
    mongoDb: {
      adapter: 'sails-mongo',
      host: 'localhost',
      port: 27017,
      database: 'yourDb'

      // Possible to add encoded symbols to the user as well
      user: 'yourUser',

      // Replacing @ with %40 to ensure connection string integrity
      password: 'your%40%40Pass', // will decode to: your@@Pass

      // New option to tell the underlying MongoClient#connect call 
      // that we've got credentials that need decoding
      uri_decode_auth: true,
    }
  }
}
```
