### PR TITLE
Fixes error with 'not' query against string field.

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -193,8 +193,8 @@ Query.prototype.parseExpression = function parseExpression(field, expression) {
           return obj;
         }
 
-        val = self.parseValue(field, modifier, val);
         modifier = _.isArray(val) ? '$nin' : '$ne';
+        val = self.parseValue(field, modifier, val);
         obj[modifier] = val;
         return obj;
       }


### PR DESCRIPTION
Fixes an error that crashes Mongo when a "not" query is run against a field of type "string".

In the following query an error is thrown due to the `modifier` variable being passed to `self.parseValue()` not being correct:

`Media.find().where({ type: { 'not': 'folder' } }).exec(function (err, results) { ... });`

This results in the query being sent to Mongo as follows:

`{ '$ne': /^folder$/i }`

Which is invalid and crashes the server with the error `MongoError: invalid regular expression operator`
