### PR TITLE
Added silly logging to warn that user or password is not provided to connection

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -133,6 +133,8 @@ Connection.prototype._buildConnection = function _buildConnection(cb) {
 
     connectionString += this.config.user + ':' + this.config.password + '@';
   }
+  else
+    sails.log.silly('Sails-mongo Apapter : user or password not provided, proceeding unauthorized')
 
   // Append the host and port
   connectionString += this.config.host + ':' + this.config.port + '/';


### PR DESCRIPTION
Added a log message if the user does not provide a 'user' or 'password' to the connection.
This will only show up if sails is run under log mode 'silly'.

This is needed because me and other's https://github.com/balderdashy/sails/issues/2448#issuecomment-65905122 seems to have had problem with local mongoDb auth understanding/finding out there were a typo.
