### PR TITLE
Create a Mongo ObjectId with Waterline

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -231,12 +231,12 @@ module.exports = (function() {
        * @param {String} id
        */
       objectId: function(id){
-	if(!id) return null;
-	try {
-	  return new ObjectId(id);
-	} catch(err) {
-	  return null;
-	}
+        if(!id) return null;
+        try {
+          return new ObjectId(id);
+        } catch(err) {
+          return null;
+        }
       }
 
     },


### PR DESCRIPTION
Hey guys!

I think that Waterline should include a method to generate a Mongo ObjectID object, so I add a little piece of code to the adapter.js file.

And that's the way that it works:

``` javascript
// Get a mongo object id in the controller
User.native(function(err, collection){
      if(err) return res.negotiate(err);
      collection.find({_id: User.mongo.objectId(req.param("id"))}).toArray(function(err, result){
        if(err) return res.negotiate(err);
        return res.send(result);
      });
});
´´´
´´´javascript
Model.mongo.objectId(req.param("id")); // returns a mongoID
```

That's really useful to do a native query which includes an ObjectId, because you can't find a document by id if you don't create a mongo ObjectID. 

Sometimes it's really important to use this objectId method, because it allows you to find models by associations ids (for example) with really complex queries that waterline doesn't have.

Thanks!  :+1:
