### PR TITLE
Fix teardown issue

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -111,18 +111,18 @@ module.exports = (function() {
      * @param {Function} callback
      */
 
-    teardown: function(connectionName, cb) {
-      if(!connections[connectionName]) return cb();
-
-      // Drain the connection pool if available
-      connections[connectionName].connection.db.close(function(err) {
-        if(err) return cb(err);
-
-        // Remove the connection from the registry
-        delete connections[connectionName];
-        cb();
-
-      });
+    teardown: function (conn, cb) {
+      if (typeof conn == 'function') {
+        cb = conn;
+        conn = null;
+      }
+      if (conn == null) {
+        connections = {};
+        return cb();
+      }
+      if(!connections[conn]) return cb();
+      delete connections[conn];
+      cb();
     },
 
     /**


### PR DESCRIPTION
Hi, I ran into an issue with the teardown while writing some tests with mocha.
Lowering sails does not teardown the database correctly so on subsequent lifts I get this error

```
A hook (`orm`) failed to load!
AdapterError: Connection is already registered
```

After some googling I found [sails-memory](https://github.com/balderdashy/sails-memory) and [sails-postgresql](https://github.com/balderdashy/sails-postgresql) had the same issue.
These issues were discussed in balderdashy/sails#1632 and  balderdashy/sails#2332. 

I tried the solution presented in balderdashy/sails-memory@545f61acb3cfe3eca01c44370414e36ce0a067e3 and balderdashy/sails-postgresql#127 and it seems to work fine.
