### PR TITLE
Add the multiline Regex flag to allow 'contains', 'like', 'startsWith' & 'endsWith' queries to work with multi-line strings.

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -205,7 +205,7 @@ Query.prototype.parseExpression = function parseExpression(field, expression) {
         if(modifier === 'contains') {
           val = utils.caseInsensitive(val);
           val =  '.*' + val + '.*';
-          obj['$regex'] = new RegExp('^' + val + '$', 'i');
+          obj['$regex'] = new RegExp('^' + val + '$', 'im');
           return obj;
         }
 
@@ -213,7 +213,7 @@ Query.prototype.parseExpression = function parseExpression(field, expression) {
         if(modifier === 'like') {
           val = utils.caseInsensitive(val);
           val = val.replace(/%/g, '.*');
-          obj['$regex'] = new RegExp('^' + val + '$', 'i');
+          obj['$regex'] = new RegExp('^' + val + '$', 'im');
           return obj;
         }
 
@@ -221,7 +221,7 @@ Query.prototype.parseExpression = function parseExpression(field, expression) {
         if(modifier === 'startsWith') {
           val = utils.caseInsensitive(val);
           val =  val + '.*';
-          obj['$regex'] = new RegExp('^' + val + '$', 'i');
+          obj['$regex'] = new RegExp('^' + val + '$', 'im');
           return obj;
         }
 
@@ -229,7 +229,7 @@ Query.prototype.parseExpression = function parseExpression(field, expression) {
         if(modifier === 'endsWith') {
           val = utils.caseInsensitive(val);
           val =  '.*' + val;
-          obj['$regex'] = new RegExp('^' + val + '$', 'i');
+          obj['$regex'] = new RegExp('^' + val + '$', 'im');
           return obj;
         }
       }

--- a/test/unit/query/adapter.query.test.js
+++ b/test/unit/query/adapter.query.test.js
@@ -233,7 +233,7 @@ describe('Query', function () {
       var where = {
         or: [{ name: { $exists: false } }, { name: { '!': 'clark' } }]
       };
-      var expect = { $or: [ { name: { $exists: false } }, { name: { $ne: /^clark$/i } } ] };
+      var expect = { $or: [ { name: { $exists: false } }, { name: { $ne: 'clark' } } ] };
       var Q = new Query({ where: where }, { name: 'string', age: 'integer' });
       var actual = Q.criteria.where;
       assert(_.isEqual(actual, expect));


### PR DESCRIPTION
In reference to issue https://github.com/balderdashy/sails-mongo/issues/220