### PR TITLE
Fix for TypeError: Cannot call method isCompatible of null. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "async": "~0.8.0",
     "lodash": "~2.4.1",
-    "mongodb": "1.4.4",
+    "mongodb": "1.4.26",
     "waterline-errors": "~0.10.0",
     "waterline-cursor": "~0.0.5"
   },


### PR DESCRIPTION
Updated dependency of mongodb nodejs driver to 1.4.26

We we're running into this issue when running on certain versions of MongoDB: https://jira.mongodb.org/browse/NODE-210
Updating to the latest mongodb nodejs driver solves the problem for us and allows all of our unit tests to complete successfully on all environments, regardless of MongoDB version on server.