### PR TITLE
Fix `numerOfRetries` -> `numberOfRetries` typo

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -114,7 +114,7 @@ Connection.prototype._buildConnection = function _buildConnection(cb) {
     forceServerObjectId: this.config.forceServerObjectId,
     recordQueryStats: this.config.recordQueryStats,
     retryMiliSeconds: this.config.retryMiliSeconds,
-    numberOfRetries: this.config.numerOfRetries
+    numberOfRetries: this.config.numberOfRetries
   };
 
   // Support for encoded auth credentials


### PR DESCRIPTION
Fix typo in connection options (`numerOfRetries` -> `numberOfRetries`)