### PR TITLE
Fix issues with string search

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -291,25 +291,6 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
   "use strict";
   var self = this;
 
-  // Look and see if the key is in the schema, id attribute and all association
-  // attributes are objectid type by default (@see { @link collection._parseDefinition }).
-  if (hop(self.schema, field) && self.schema[field].type === 'objectid') {
-
-    // Check for array of Mongo ObjectId
-    // If we have an array of IDs, attempt to make ObjectIds out of them.
-    if (_.isArray(val)) {
-      return _.map(val, function (item) {
-        return _.isString(item) && utils.matchMongoId(item) ? new ObjectId(item) : item;
-      });
-    }
-
-    // Check for Mongo ObjectId
-    if (_.isString(val) && utils.matchMongoId(val)) {
-      return new ObjectId(val.toString());
-    }
-
-  }
-
   if(_.isString(val)) {
 
     // If we can verify that the field is NOT a string type, translate
@@ -325,16 +306,21 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
         return parseFloat(val);
       }
 
-      if (val === "false") {
+      if(/^\d{4}-\d{2}-\d{2}[T ]\d{2}\:\d{2}\:\d{2}\.\d{3}Z$/.test(val) && self.schema[field].type == 'date' || self.schema[field].type == 'datetime') {
+        return new Date(val);
+      }
+
+      if(/^[1-9]\d{3}-\d{1,2}-\d{1,2}$/.test(val) && self.schema[field].type == 'date') {
+        var parts = val.split('-');
+        return new Date(parts[0], parts[1] - 1, parts[2]);
+      }
+
+      if (val === "false" && self.schema[field].type == 'boolean') {
         return false;
       }
 
-      if (val === "true") {
+      if (val === "true" && self.schema[field].type == 'boolean') {
         return true;
-      }
-
-      if (val === "null") {
-        return null;
       }
 
     }
@@ -343,10 +329,6 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
       return val;
     }
 
-    // Replace Percent Signs, work in a case insensitive fashion by default
-    val = utils.caseInsensitive(val);
-    val = val.replace(/%/g, '.*');
-    val = new RegExp('^' + val + '$', 'i');
     return val;
   }
 


### PR DESCRIPTION
We shouldn't change all string searches into regexp search. It will invalid all indexes on these fields. Tasks for converting wildcard characters like `%` to regexp are already done previously with matched modifier. Also if the schema type is `date` or `datetime`, it's better to support string type date query, they might from a blueprint query so it can't be searched if we don't convert it to `Date` object.