### PR TITLE
Fix issues with string search

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -325,16 +325,21 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
         return parseFloat(val);
       }
 
-      if (val === "false") {
+      if(/^\d{4}-\d{2}-\d{2}[T ]\d{2}\:\d{2}\:\d{2}\.\d{3}Z$/.test(val) && self.schema[field].type == 'date' || self.schema[field].type == 'datetime') {
+        return new Date(val);
+      }
+
+      if(/^[1-9]\d{3}-\d{1,2}-\d{1,2}$/.test(val) && self.schema[field].type == 'date') {
+        var parts = val.split('-');
+        return new Date(parts[0], parts[1] - 1, parts[2]);
+      }
+
+      if (val === "false" && self.schema[field].type == 'boolean') {
         return false;
       }
 
-      if (val === "true") {
+      if (val === "true" && self.schema[field].type == 'boolean') {
         return true;
-      }
-
-      if (val === "null") {
-        return null;
       }
 
     }
@@ -343,10 +348,6 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
       return val;
     }
 
-    // Replace Percent Signs, work in a case insensitive fashion by default
-    val = utils.caseInsensitive(val);
-    val = val.replace(/%/g, '.*');
-    val = new RegExp('^' + val + '$', 'i');
     return val;
   }
 

--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -325,7 +325,7 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
         return parseFloat(val);
       }
 
-      if(/^\d{4}-\d{2}-\d{2}[T ]\d{2}\:\d{2}\:\d{2}(\.\d{3})?Z?$/.test(val) && self.schema[field].type === 'date' || self.schema[field].type === 'datetime') {
+      if(/^\d{4}-\d{2}-\d{2}[T ]\d{2}\:\d{2}\:\d{2}(\.\d{3})?Z?$/.test(val) && self.schema[field].type === 'date' || (self.schema[field].type === 'datetime')) {
         return new Date(val);
       }
 

--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -325,7 +325,7 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
         return parseFloat(val);
       }
 
-      if(/^\d{4}-\d{2}-\d{2}[T ]\d{2}\:\d{2}\:\d{2}\.\d{3}Z$/.test(val) && self.schema[field].type === 'date' || self.schema[field].type === 'datetime') {
+      if(/^\d{4}-\d{2}-\d{2}[T ]\d{2}\:\d{2}\:\d{2}(\.\d{3})?Z?$/.test(val) && self.schema[field].type === 'date' || self.schema[field].type === 'datetime') {
         return new Date(val);
       }
 

--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -329,7 +329,7 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
         return new Date(val);
       }
 
-      if(/^[1-9]\d{3}-\d{1,2}-\d{1,2}$/.test(val) && self.schema[field].type === 'date') {
+      if(/^\d{4}-\d{1,2}-\d{1,2}$/.test(val) && self.schema[field].type === 'date') {
         var parts = val.split('-');
         return new Date(parts[0], parts[1] - 1, parts[2]);
       }

--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -325,7 +325,7 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
         return parseFloat(val);
       }
 
-      if(/^\d{4}-\d{2}-\d{2}[T ]\d{2}\:\d{2}\:\d{2}(\.\d{3})?Z?$/.test(val) && self.schema[field].type === 'date' || (self.schema[field].type === 'datetime')) {
+      if(/^\d{4}-\d{2}-\d{2}[T ]\d{2}\:\d{2}\:\d{2}(\.\d{3})?Z?$/.test(val) && (self.schema[field].type === 'date' || self.schema[field].type === 'datetime')) {
         return new Date(val);
       }
 

--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -325,20 +325,20 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
         return parseFloat(val);
       }
 
-      if(/^\d{4}-\d{2}-\d{2}[T ]\d{2}\:\d{2}\:\d{2}\.\d{3}Z$/.test(val) && self.schema[field].type == 'date' || self.schema[field].type == 'datetime') {
+      if(/^\d{4}-\d{2}-\d{2}[T ]\d{2}\:\d{2}\:\d{2}\.\d{3}Z$/.test(val) && self.schema[field].type === 'date' || self.schema[field].type === 'datetime') {
         return new Date(val);
       }
 
-      if(/^[1-9]\d{3}-\d{1,2}-\d{1,2}$/.test(val) && self.schema[field].type == 'date') {
+      if(/^[1-9]\d{3}-\d{1,2}-\d{1,2}$/.test(val) && self.schema[field].type === 'date') {
         var parts = val.split('-');
         return new Date(parts[0], parts[1] - 1, parts[2]);
       }
 
-      if (val === "false" && self.schema[field].type == 'boolean') {
+      if (val === "false" && self.schema[field].type === 'boolean') {
         return false;
       }
 
-      if (val === "true" && self.schema[field].type == 'boolean') {
+      if (val === "true" && self.schema[field].type === 'boolean') {
         return true;
       }
 

--- a/test/unit/query/adapter.query.test.js
+++ b/test/unit/query/adapter.query.test.js
@@ -233,7 +233,7 @@ describe('Query', function () {
       var where = {
         or: [{ name: { $exists: false } }, { name: { '!': 'clark' } }]
       };
-      var expect = { $or: [ { name: { $exists: false } }, { name: { $ne: /^clark$/i } } ] };
+      var expect = { $or: [ { name: { $exists: false } }, { name: { $ne: 'clark' } } ] };
       var Q = new Query({ where: where }, { name: 'string', age: 'integer' });
       var actual = Q.criteria.where;
       assert(_.isEqual(actual, expect));


### PR DESCRIPTION
We shouldn't change all string searches into regexp ones. It will invalid all indexes and greatly hurt performance.
Tasks for converting wildcard characters like `%` to regexp are already done previously and we should only do it when it's with certain matched modifier like `like`. So in `parseValue` method we should not do it again.
Let's say in some edge cases, when a user wants to search string with `null` or `true` or anything contains '%' as a string value, he / she cannot do it since it's been converted to other types and will return wrong result.
Also if the schema type is `date` or `datetime`, it's better to support string type date query, they might from a blueprint query so it can't be searched if we don't convert it to `Date` object.