### PR TITLE
Use MongoDB fields projection on update to reduce the memory footpints

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -224,22 +224,10 @@ Collection.prototype.update = function update(criteria, values, cb) {
     if(err) return cb(err);
     if(!records) return cb(Errors.NotFound);
 
-    // Build an array of records
-    var updatedRecords = [];
-
-    records.forEach(function(record) {
-      updatedRecords.push(record._id);
-    });
-
     // Update the records
     collection.update(query.criteria.where, { '$set': values }, { multi: true }, function(err, result) {
       if(err) return cb(err);
-
-      // Look up newly inserted records to return the results of the update
-      collection.find({ _id: { '$in': updatedRecords }}).toArray(function(err, records) {
-        if(err) return cb(err);
-        cb(null, utils.rewriteIds(records, self.schema));
-      });
+      cb(null, utils.rewriteIds(records, self.schema));
     });
   });
 };

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -220,7 +220,7 @@ Collection.prototype.update = function update(criteria, values, cb) {
   // Lookup records being updated and grab their ID's
   // Useful for later looking up the record after an insert
   // Required because options may not contain an ID
-  collection.find(query.criteria.where, {_id: 1}).toArray(function(err, records) {
+  collection.find(query.criteria.where).toArray(function(err, records) {
     if(err) return cb(err);
     if(!records) return cb(Errors.NotFound);
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -220,7 +220,7 @@ Collection.prototype.update = function update(criteria, values, cb) {
   // Lookup records being updated and grab their ID's
   // Useful for later looking up the record after an insert
   // Required because options may not contain an ID
-  collection.find(query.criteria.where).toArray(function(err, records) {
+  collection.find(query.criteria.where, {_id: 1}).toArray(function(err, records) {
     if(err) return cb(err);
     if(!records) return cb(Errors.NotFound);
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -220,14 +220,26 @@ Collection.prototype.update = function update(criteria, values, cb) {
   // Lookup records being updated and grab their ID's
   // Useful for later looking up the record after an insert
   // Required because options may not contain an ID
-  collection.find(query.criteria.where).toArray(function(err, records) {
+  collection.find(query.criteria.where, {_id: 1}).toArray(function(err, records) {
     if(err) return cb(err);
     if(!records) return cb(Errors.NotFound);
+
+    // Build an array of records
+    var updatedRecords = [];
+
+    records.forEach(function(record) {
+      updatedRecords.push(record._id);
+    });
 
     // Update the records
     collection.update(query.criteria.where, { '$set': values }, { multi: true }, function(err, result) {
       if(err) return cb(err);
-      cb(null, utils.rewriteIds(records, self.schema));
+
+      // Look up newly inserted records to return the results of the update
+      collection.find({ _id: { '$in': updatedRecords }}).toArray(function(err, records) {
+        if(err) return cb(err);
+        cb(null, utils.rewriteIds(records, self.schema));
+      });
     });
   });
 };

--- a/test/unit/query/adapter.query.test.js
+++ b/test/unit/query/adapter.query.test.js
@@ -233,7 +233,7 @@ describe('Query', function () {
       var where = {
         or: [{ name: { $exists: false } }, { name: { '!': 'clark' } }]
       };
-      var expect = { $or: [ { name: { $exists: false } }, { name: { $ne: /^clark$/i } } ] };
+      var expect = { $or: [ { name: { $exists: false } }, { name: { $ne: 'clark' } } ] };
       var Q = new Query({ where: where }, { name: 'string', age: 'integer' });
       var actual = Q.criteria.where;
       assert(_.isEqual(actual, expect));


### PR DESCRIPTION
As the discussion in another issue balderdashy/waterline#805, I would suggest for an update operation, it's not needed to return the full updated result set. But even it's for compatibility reason we keep it, it should have an option to turn it off. At lease, if for now there's no plan to do it, we can use MongoDB projection when only fetching the needed `_id` field in the first find query