### PR TITLE
Option to enable case sensitive requests (performance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ module.exports.adapters = {
     port: 27017,
     user: 'username',
     password: 'password',
-    database: 'your mongo db name here'
+    database: 'your mongo db name here',
+    wlNext: {
+      caseSensitive: false
+    }
   }
 };
 ```

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -63,7 +63,20 @@ module.exports = (function() {
         socketTimeoutMS: 5000
       },
       auto_reconnect: false,
-      disableDriverBSONSizeCheck: false
+      disableDriverBSONSizeCheck: false,
+
+
+      // Waterline NEXT
+      // These are flags that can be toggled today and expose future features. If any of the following are turned
+      // on the adapter tests will probably not pass. If you toggle these know what you are getting into.
+      wlNext: {
+        
+        // Case sensitive - false
+        // In the next version of WL queries will be case sensitive by default.
+        // Set this to true to experiment with that feature today.
+        caseSensitive: false
+
+      }
 
     },
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -29,6 +29,10 @@ var Collection = module.exports = function Collection(definition, connection) {
   // Hold a reference to an active connection
   this.connection = connection;
 
+  // Hold the config object
+  var connectionConfig = connection.config || {};
+  this.config = _.extend({}, connectionConfig.wlNext);
+
   // Hold Indexes
   this.indexes = [];
 
@@ -65,7 +69,7 @@ Collection.prototype.find = function find(criteria, cb) {
 
   // Catch errors from building query and return to the callback
   try {
-    query = new Query(criteria, this.schema);
+    query = new Query(criteria, this.schema, this.config);
   } catch(err) {
     return cb(err);
   }
@@ -122,7 +126,7 @@ Collection.prototype.stream = function find(criteria, stream) {
 
   // Catch errors from building query and return to the callback
   try {
-    query = new Query(criteria, this.schema);
+    query = new Query(criteria, this.schema, this.config);
   } catch(err) {
     return stream.end(err); // End stream
   }
@@ -204,7 +208,7 @@ Collection.prototype.update = function update(criteria, values, cb) {
 
   // Catch errors build query and return to the callback
   try {
-    query = new Query(criteria, this.schema);
+    query = new Query(criteria, this.schema, this.config);
   } catch(err) {
     return cb(err);
   }
@@ -263,7 +267,7 @@ Collection.prototype.destroy = function destroy(criteria, cb) {
 
   // Catch errors build query and return to the callback
   try {
-    query = new Query(criteria, this.schema);
+    query = new Query(criteria, this.schema, this.config);
   } catch(err) {
     return cb(err);
   }
@@ -310,7 +314,7 @@ Collection.prototype.count = function count(criteria, cb) {
 
   // Catch errors build query and return to the callback
   try {
-    query = new Query(criteria, this.schema);
+    query = new Query(criteria, this.schema, this.config);
   } catch(err) {
     return cb(err);
   }

--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -348,6 +348,7 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
     }
 
     // Replace Percent Signs, work in a case insensitive fashion by default
+    // Turn wlNext.caseSensitive flag to `true` to enable case sensitive requests when there is no modifier
     if(!this.config.caseSensitive || modifier) {
       val = utils.caseInsensitive(val);
       val = val.replace(/%/g, '.*');

--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -15,16 +15,20 @@ var _ = require('lodash'),
  * Normalizes Waterline queries to work with Mongo.
  *
  * @param {Object} options
+ * @param {Object} [config]
  * @api private
  */
 
-var Query = module.exports = function Query(options, schema) {
+var Query = module.exports = function Query(options, schema, config) {
 
   // Flag as an aggregate query or not
   this.aggregate = false;
 
   // Cache the schema for use in parseTypes
   this.schema = schema;
+
+  // Hold the config object
+  this.config = config || {};
 
   // Check for Aggregate Options
   this.checkAggregate(options);
@@ -344,9 +348,11 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
     }
 
     // Replace Percent Signs, work in a case insensitive fashion by default
-    val = utils.caseInsensitive(val);
-    val = val.replace(/%/g, '.*');
-    val = new RegExp('^' + val + '$', 'i');
+    if(!this.config.caseSensitive || modifier) {
+      val = utils.caseInsensitive(val);
+      val = val.replace(/%/g, '.*');
+      val = new RegExp('^' + val + '$', 'i');
+    }
     return val;
   }
 


### PR DESCRIPTION
Hi there,

The goal here was to deal with the old issue of strings search. Indeed, we are currently facing slow queries in our project — large Mongo collections used there — which are due because of the RegExp parsing. We actually want to perform searchs with the string with provide, which means *case sensitive* requests.

After digging into issues/PR of the project, I made this modification according to what you specified in PR #235 :

- configuration flag to be turned on to enable the feature, don't break regular functionality
- use `wlNext` config convention, following the work you started over waterline sequel (see https://github.com/balderdashy/waterline-sequel/commit/62ec93e232ec9f3c18956e23b48247c947d101c3)

I tested this branch against our project, and I didn't find any issue for now. Doing so I found out that you still need to perform the RegExp conversion when dealing with a modifier (e.g. `$not`) since Mongo doesn't allow a string but either a RegExp or a document (see http://docs.mongodb.org/manual/reference/operator/query/not/).


Please let me know if something is wrong. 
I personally have one test failing, but it also fails on `master` branch, which I don't understand for now. I may need to add some unit tests too. Just let me know ;-) 

Thanks.