### PR TITLE
added newline-support for like and contains

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -205,7 +205,7 @@ Query.prototype.parseExpression = function parseExpression(field, expression) {
         if(modifier === 'contains') {
           val = utils.caseInsensitive(val);
           val =  '.*' + val + '.*';
-          obj['$regex'] = new RegExp('^' + val + '$', 'i');
+          obj['$regex'] = new RegExp('^' + val + '$', 'im');
           return obj;
         }
 
@@ -213,7 +213,7 @@ Query.prototype.parseExpression = function parseExpression(field, expression) {
         if(modifier === 'like') {
           val = utils.caseInsensitive(val);
           val = val.replace(/%/g, '.*');
-          obj['$regex'] = new RegExp('^' + val + '$', 'i');
+          obj['$regex'] = new RegExp('^' + val + '$', 'im');
           return obj;
         }
 


### PR DESCRIPTION
Added the regex `m`-modifier to the `like` and `contains'  helper function in order to support multiline searches.