### PR TITLE
Re-apply fix for #177 and add condition for 'datetime' type

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -337,6 +337,14 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
         return null;
       }
 
+      if (self.schema[field].type === 'datetime') {
+        return new Date(val);
+      }
+
+      if (self.schema[field].type === 'date') {
+        return new Date(val);
+      }
+      
     }
 
     if(modifier === '$ne') {


### PR DESCRIPTION
Fix for parsing exception when filtering by date or datetime.

fixes #177 
fixes #1743 in "sails"