### PR TITLE
Allow for > or < query on string

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -345,6 +345,11 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
         return new Date(val);
       }
       
+      // regex check for <,>,>=,<=,lt,gt,lte,gte,$lt,$gt,$lte,$gte ect . ..  
+      if(/(=*[<>]=*)|(\$*[gl]te*)/.test(modifier)){
+        return val;
+      }
+      
     }
 
     if(modifier === '$ne') {


### PR DESCRIPTION
It would appear that you can not do a greater than or less than query on a string due to the regex transformation of the value being searched. This will escape that transformation if the the search being preformed is a less than or greater than query.