### PR TITLE
Add badges and return non-zero if build breaks tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
-  - "0.8"
 services:
   - mongodb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![](https://camo.githubusercontent.com/9e49073459ed4e0e2687b80eaf515d87b0da4a6b/687474703a2f2f62616c64657264617368792e6769746875622e696f2f7361696c732f696d616765732f6c6f676f2e706e67)](http://sailsjs.org/#!)
 
 # sails-mongo
+[![Build Status](https://travis-ci.org/balderdashy/sails-mongo.svg?branch=master)](https://travis-ci.org/balderdashy/sails-mongo)
+[![npm version](https://badge.fury.io/js/sails-mongo.svg)](http://badge.fury.io/js/sails-mongo)
+[![Dependency Status](https://david-dm.org/balderdashy/sails-mongo.svg)](https://david-dm.org/balderdashy/sails-mongo)
 
 Waterline adapter for MongoDB.
 

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -75,7 +75,16 @@ new TestRunner({
 
   // The set of adapter interfaces to test against.
   // (grabbed these from this adapter's package.json file above)
-  interfaces: interfaces
+  interfaces: interfaces,
+    
+  // Mocha options
+  // reference: https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically
+  mocha: {},
+    
+  mochaChainableMethods: {},
+    
+  // Return code != 0 if any test failed
+  failOnError: true
 
   // Most databases implement 'semantic' and 'queryable'.
   //


### PR DESCRIPTION
~~Currently the build is broken and it always shows error: [![Build Status](https://travis-ci.org/balderdashy/sails-mongo.svg?branch=master)](https://travis-ci.org/balderdashy/sails-mongo), instead of "failing" / "passing". This PR fixes that by removing node 0.8 from travis.yml.~~

Additionally this PR adds:
* badges to the README;
* Integration tests: `failOnError: true`. so the build actually fails instead of wrongfully passing.