### PR TITLE
Remove cloning of ObjectID upon insert, etc.

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -74,7 +74,7 @@ Document.prototype.normalizeId = function normalizeId(values) {
     values.id = new ObjectId.createFromHexString(values.id);
   }
 
-  values._id = _.cloneDeep(values.id);
+  values._id = values.id;
   delete values.id;
 };
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -71,10 +71,13 @@ Document.prototype.normalizeId = function normalizeId(values) {
 
   // Check if data.id looks like a MongoID
   if(_.isString(values.id) && values.id.match(/^[a-fA-F0-9]{24}$/)) {
-    values.id = new ObjectId.createFromHexString(values.id);
+    
+    values._id = new ObjectId.createFromHexString(values.id);
+  } else {
+  
+    values._id = _.cloneDeep(values.id);
   }
-
-  values._id = values.id;
+  
   delete values.id;
 };
 


### PR DESCRIPTION
This fixes an issue around creating records with specified mongo IDs.  In particular, this resolves an error that occurs when attempting to associate records during record creation.  See https://github.com/balderdashy/waterline/issues/908

The cloning step that used to happen here would clone a mongo ObjectId object, which would only happen incompletely due to the object's prototype.  In particular, it had its own `toString` method which was typically used to return the string representation of the mongo id.  Instead, you'd get `[object Object]` as an id!  D'oh!

CC @anasyb @particlebanana 