### PR TITLE
fix unnecessary cloneDeep circular structure

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -355,11 +355,10 @@ Collection.prototype._getPK = function _getPK () {
  */
 
 Collection.prototype._parseDefinition = function _parseDefinition(definition) {
-  var self = this,
-      collectionDef = _.cloneDeep(definition);
+  var self = this;
 
   // Hold the Schema
-  this.schema = collectionDef.definition;
+  this.schema = _.cloneDeep(definition.definition);
 
   if (_.has(this.schema, 'id') && this.schema.id.primaryKey && this.schema.id.type === 'integer') {
     this.schema.id.type = 'objectid';


### PR DESCRIPTION
remove unnecessary cloneDeep circular structure when only one attribute is needed.
i kept the cloneDeep of attribute incase it would be needed somewhere.
fixes #253