### PR TITLE
Fix for issue #266. Socket timeout due to inactivity after socket is …

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -63,8 +63,9 @@ module.exports = (function() {
         connectTimeoutMS: 5000,
         socketTimeoutMS: 5000
       },
-      auto_reconnect: false,
-      disableDriverBSONSizeCheck: false
+      auto_reconnect: true,
+      disableDriverBSONSizeCheck: false,
+      reconnectInterval: 200
 
     },
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -100,7 +100,8 @@ Connection.prototype._buildConnection = function _buildConnection(cb) {
     poolSize: this.config.poolSize,
     socketOptions: this.config.socketOptions,
     auto_reconnect: this.config.auto_reconnect,
-    disableDriverBSONSizeCheck: this.config.disableDriverBSONSizeCheck
+    disableDriverBSONSizeCheck: this.config.disableDriverBSONSizeCheck,
+    reconnectInterval: this.config.reconnectInterval
   };
 
   // Build up options used for creating a Database instance


### PR DESCRIPTION
This pull request is to address issue #266. This is caused by socket inactivity after the socket connection is open. Mongo-core lib v1.1.25 introduced the topology exception when the application try to do operations on closed connection. The default settings for this fix should help to reestablish the connection again with optimal time interval.