### PR TITLE
Fix binary type returned by .find()

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -100,7 +100,7 @@ Collection.prototype.find = function find(criteria, cb) {
   // Run Normal Query on collection
   collection.find(where, queryOptions).toArray(function(err, docs) {
     if(err) return cb(err);
-    cb(null, utils.rewriteIds(docs, self.schema));
+    cb(null, utils.normalizeResults(docs, self.schema));
   });
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,6 +27,39 @@ exports.object.hasOwnProperty = function(obj, prop) {
   return hop.call(obj, prop);
 };
 
+
+/**
+ * Re-Write Mongo's _id attribute to a normalized id attribute in single document
+ *
+ * @param {Object} models
+ * @api private
+ */
+
+exports._rewriteIds = function(model, schema) {
+  if (hop.call(model, '_id')) {
+    // change id to string only if it's necessary
+    if (typeof model._id === 'object')
+      model.id = model._id.toString();
+    else
+      model.id = model._id;
+    delete model._id;
+  }
+
+  // Rewrite any foreign keys if a schema is available
+  if (!schema) return model;
+
+  Object.keys(schema).forEach(function (key) {
+    var foreignKey = schema[key].foreignKey || false;
+
+    // If a foreignKey, check if value matches a mongo id and if so turn it into an objectId
+    if (foreignKey && model[key] instanceof ObjectId) {
+      model[key] = model[key].toString();
+    }
+  });
+
+  return model;
+};
+
 /**
  * Re-Write Mongo's _id attribute to a normalized id attribute
  *
@@ -35,31 +68,9 @@ exports.object.hasOwnProperty = function(obj, prop) {
  */
 
 exports.rewriteIds = function rewriteIds(models, schema) {
-  var _models = models.map(function(model) {
-    if(hop.call(model, '_id')) {
-      // change id to string only if it's necessary
-      if(typeof model._id === 'object')
-        model.id = model._id.toString();
-      else
-        model.id = model._id;
-      delete model._id;
-    }
-
-    // Rewrite any foreign keys if a schema is available
-    if(!schema) return model;
-
-    Object.keys(schema).forEach(function(key) {
-      var foreignKey = schema[key].foreignKey || false;
-
-      // If a foreignKey, check if value matches a mongo id and if so turn it into an objectId
-      if(foreignKey && model[key] instanceof ObjectId) {
-        model[key] = model[key].toString();
-      }
-    });
-
-    return model;
+  var _models = models.map(function(model){
+    return exports._rewriteIds(model, schema);
   });
-
   return _models;
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,7 @@
 
 var _ = require('lodash'),
     ObjectId = require('mongodb').ObjectID,
+    MongoBinary = require('mongodb').Binary,
     url = require('url');
 
 /**
@@ -70,6 +71,26 @@ exports._rewriteIds = function(model, schema) {
 exports.rewriteIds = function rewriteIds(models, schema) {
   var _models = models.map(function(model){
     return exports._rewriteIds(model, schema);
+  });
+  return _models;
+};
+
+/**
+ * Normalize documents retrieved from MongoDB to match Waterline's expectations
+ *
+ * @param {Array} models
+ * @api public
+ */
+
+exports.normalizeResults = function normalizeResults(models, schema) {
+  var _models = models.map(function (model) {
+    var _model = exports._rewriteIds(model, schema);
+    Object.keys(_model).forEach(function (key) {
+      if (model[key] instanceof MongoBinary && _.has(_model[key], 'buffer')) {
+        _model[key] = _model[key].buffer;
+      }
+    });
+    return _model;
   });
   return _models;
 };


### PR DESCRIPTION
Fixes #272 by processing the documents returned from MongoDB and replacing any mongo `Binary` for `Binary.buffer` thus satisfying waterline's expectations and passing the tests added in PR balderdashy/waterline-adapter-tests#66.

This PR has 2 commits:

1. refactored `.rewriteIds()` so we can re-use its inner logic in `.normalizeResults()`;
2. Adds `.normalizeResults()` to process mongodb documents and do the appropriate transformations.

Any feedback is welcomed!

As explained in #272:
> PR balderdashy/waterline-adapter-tests#66 exposes a bug in sails-mongo where binary type is not correctly saved and returned. The relevant test is: 
> ```javascript
>       it('should store proper binary value', function(done) {
>         // use a string
>         var str = 'test the things';
>         // to make a binary thing
>         var buf = new Buffer(str, "utf-8");
>         // store the binary thing
>         Semantic.User.create({ avatar: buf }, function(err, createdRecord) {
>           assert(!err, err);
>           Semantic.User.findOne({id: createdRecord.id}, function (err, record) {
>               assert(!err);
>               // read out the stored binary thing
>               var outbuf = new Buffer(record.avatar);
>               assert(outbuf.toString('utf-8') === str);
>               done();
>            });
>         });
>       });
> ```
> 
> The other official adapters pass this test.

cc: @khalilTN, @devinivy, @atiertant, @andypham 