### PR TITLE
Enforce driver server option defaults, no socket timeout.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -63,7 +63,7 @@ module.exports = (function() {
         connectTimeoutMS: 0,
         socketTimeoutMS: 0
       },
-      autoReconnect: true,
+      auto_reconnect: true,
       disableDriverBSONSizeCheck: false,
       reconnectInterval: 200
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -56,14 +56,14 @@ module.exports = (function() {
 
       // Server Options
       ssl: false,
-      poolSize: 1,
+      poolSize: 5,
       socketOptions: {
-        noDelay: false,
+        noDelay: true,
         keepAlive: 0,
-        connectTimeoutMS: 5000,
-        socketTimeoutMS: 5000
+        connectTimeoutMS: 0,
+        socketTimeoutMS: 0
       },
-      auto_reconnect: true,
+      autoReconnect: true,
       disableDriverBSONSizeCheck: false,
       reconnectInterval: 200
 


### PR DESCRIPTION
Ref: http://mongodb.github.io/node-mongodb-native/2.0/api/Server.html
The idea here is to set the default mongo server settings in the adapter to the mongo driver's default settings.  Most notably, this does two things:

1. Set the TCP socket timeout to zero, which indicates that the socket connection to mongod should not timeout after a certain length of inactivity (i.e., making no queries).
2. Increase pool size to 5, which should allow for better default request concurrency and cover more use-cases out-of-the-box.

Hopefully this will resolve #266 #275 #276 – please test!

CC @dmarcelino @andypham