### PR TITLE
Enable feature cross-adapter tests 

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
       "semantic",
       "queryable",
       "associations"
+    ],
+    "features": [
+      "cross-adapter"
     ]
   }
 }

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -22,10 +22,12 @@ var Adapter = require('../../lib/adapter');
 
 // Grab targeted interfaces from this adapter's `package.json` file:
 var package = {},
-  interfaces = [];
+  interfaces = [],
+  features = [];
 try {
   package = require('../../package.json');
   interfaces = package.waterlineAdapter.interfaces;
+  features = package.waterlineAdapter.features;
 } catch (e) {
   throw new Error(
     '\n' +
@@ -76,10 +78,16 @@ new TestRunner({
   // The set of adapter interfaces to test against.
   // (grabbed these from this adapter's package.json file above)
   interfaces: interfaces,
+  
+  // The set of adapter features to test against.
+  // (grabbed these from this adapter's package.json file above)
+  features: features,
     
   // Mocha options
   // reference: https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically
-  mocha: {},
+  mocha: {
+    reporter: 'spec'
+  },
     
   mochaChainableMethods: {},
     


### PR DESCRIPTION
To make use of the new cross-adapter tests introduced by balderdashy/waterline-adapter-tests#64.

This also changes the reporter to 'spec' which makes it easier to check which test ran and passed.