### PR TITLE
Travis: falling back to mongo 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,5 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-before_script:
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
-  - sudo apt-get update
-  - sudo apt-get install -y mongodb-org=2.6.5 mongodb-org-server=2.6.5 mongodb-org-shell=2.6.5 mongodb-org-mongos=2.6.5 mongodb-org-tools=2.6.5
-  - sleep 15 #mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
-  - mongo --version
 services:
   - mongodb


### PR DESCRIPTION
Since the build will run quicker as it won't have to install MongoDB 2.6.5.