### PR TITLE
allow searching including newlines

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -212,7 +212,7 @@ Query.prototype.parseExpression = function parseExpression(field, expression) {
         // Handle `contains` by building up a case insensitive regex
         if(modifier === 'contains') {
           val = utils.caseInsensitive(val);
-          val =  '.*' + val + '.*';
+          val =  '[\\s\\S]*' + val + '[\\s\\S]*';
           obj['$regex'] = new RegExp('^' + val + '$', 'i');
           return obj;
         }
@@ -220,7 +220,7 @@ Query.prototype.parseExpression = function parseExpression(field, expression) {
         // Handle `like`
         if(modifier === 'like') {
           val = utils.caseInsensitive(val);
-          val = val.replace(/%/g, '.*');
+          val = val.replace(/%/g, '[\\s\\S]*');
           obj['$regex'] = new RegExp('^' + val + '$', 'i');
           return obj;
         }
@@ -228,7 +228,7 @@ Query.prototype.parseExpression = function parseExpression(field, expression) {
         // Handle `startsWith` by setting a case-insensitive regex
         if(modifier === 'startsWith') {
           val = utils.caseInsensitive(val);
-          val =  val + '.*';
+          val =  val + '[\\s\\S]*';
           obj['$regex'] = new RegExp('^' + val + '$', 'i');
           return obj;
         }
@@ -236,7 +236,7 @@ Query.prototype.parseExpression = function parseExpression(field, expression) {
         // Handle `endsWith` by setting a case-insensitive regex
         if(modifier === 'endsWith') {
           val = utils.caseInsensitive(val);
-          val =  '.*' + val;
+          val =  '[\\s\\S]*' + val;
           obj['$regex'] = new RegExp('^' + val + '$', 'i');
           return obj;
         }
@@ -366,7 +366,7 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
     }
     // Replace Percent Signs, work in a case insensitive fashion by default
     val = utils.caseInsensitive(val);
-    val = val.replace(/%/g, '.*');
+    val = val.replace(/%/g, '[\\s\\S]*');
     val = new RegExp('^' + val + '$', 'i');
     return val;
   }


### PR DESCRIPTION
Use a match any character set ([\s\S] instead of .) to fix 'contains', 'like', 'startsWith', and 'endsWith' queries to work with multi-line strings.

This is a different way of solving the problem of #220 and #221, and it was recommended by @andyhu as a better way of solving the problem than adding the `m` flag, which breaks `startsWith` and `endsWith`.

My specific use case is similar to the HTML one - I want to search across a string of markdown that has newlines in it.