### PR TITLE
teardown: when conn==null, teardown all connections

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -11,7 +11,7 @@ var _runJoins = require('waterline-cursor');
 var util = require('util');
 var _ = require('lodash');
 var utils = require('./utils');
-
+var async = require('async');
 
 module.exports = (function() {
 
@@ -132,8 +132,11 @@ module.exports = (function() {
         conn = null;
       }
       if (conn == null) {
+        var dbs = _.pluck(_.pluck(_.values(connections), 'connection'), 'db');
         connections = {};
-        return cb();
+        return async.each(dbs, function (db, onClosed) {
+          db.close(onClosed);
+        }, cb);
       }
       if(!connections[conn]) return cb();
 


### PR DESCRIPTION
This fixes case, when sails passes conn==null to adapter.teardown
and expects the adapter to tear down all connections:
https://github.com/balderdashy/sails/blob/faf92e321c9ddb9750720f5e6a405bbf15724a50/lib/hooks/orm/index.js#L219