### PR TITLE
parseDefinition: recognize objectid in id attribute

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -341,6 +341,14 @@ Collection.prototype._getPK = function _getPK () {
   return pk;
 };
 
+function defaultsToObjectId(attribute) {
+  if (typeof attribute.defaultsTo === 'function') {
+    return utils.matchMongoId(attribute.defaultsTo());
+  } else if (typeof attribute.defaultsTo === 'string') {
+    return utils.matchMongoId(attribute.defaultsTo);
+  }
+  return false;
+}
 
 /**
  * Parse Collection Definition
@@ -355,7 +363,7 @@ Collection.prototype._parseDefinition = function _parseDefinition(definition) {
   // Hold the Schema
   this.schema = _.cloneDeep(definition.definition);
 
-  if (_.has(this.schema, 'id') && this.schema.id.primaryKey && this.schema.id.type === 'integer') {
+  if (_.has(this.schema, 'id') && this.schema.id.primaryKey && (this.schema.id.type === 'integer' || defaultsToObjectId(this.schema.id))) {
     this.schema.id.type = 'objectid';
   }
 


### PR DESCRIPTION
Support usecase, when a model has this id attribute:

```
{
  type: 'string',
  primaryKey: true,
  unique: true,
  defaultsTo: function () {
    return new ObjectId().toString();
  }
}
```

edit: changed type from `text` to `string`