### PR TITLE
Return nothing when explicitly querying for an undefined id

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -58,6 +58,11 @@ Collection.prototype.find = function find(criteria, cb) {
   var self = this,
       query;
 
+  // Nothing should be returned when looking for an explicitly undefined id
+  if(criteria.where && "id" in criteria.where && criteria.where.id === undefined) {
+    return cb(null, []);
+  }
+
   // Catch errors from building query and return to the callback
   try {
     query = new Query(criteria, this.schema);


### PR DESCRIPTION
This fixes the issue where a nulled *-to-one relationship would return an invalid value when populated.

More specifically, I found that in a many-to-one relationship, where the "one"'s relation to the "many" was optional thus nullable, it would return an invalid value since a find call would be issued with criteria `{where: {id: undefined}}`.
`sails-mongo` treats such a query as "return everything", while `sails-memory` treats it as "return nothing".

More obviously, would be the following query:
```js
User.findOne({where: {id: undefined}}).exec(console.log);
```
This would return nothing under `sails-memory`, but `sails-mongo` will return the first user object.