### PR TITLE
Produce WLValidationError when a unique constraint is violated

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -10,6 +10,7 @@ var ObjectId = require('mongodb').ObjectID;
 var _runJoins = require('waterline-cursor');
 var util = require('util');
 var _ = require('lodash');
+var utils = require('./utils');
 
 
 module.exports = (function() {
@@ -276,7 +277,7 @@ module.exports = (function() {
 
       // Insert a new document into the collection
       collection.insert(data, function(err, results) {
-        if(err) return cb(err);
+        if(err) return cb(utils.clarifyError(err));
         cb(null, results[0]);
       });
     },
@@ -301,7 +302,7 @@ module.exports = (function() {
 
       // Insert a new document into the collection
       collection.insert(data, function(err, results) {
-        if(err) return cb(err);
+        if(err) return cb(utils.clarifyError(err));
         cb(null, results);
       });
     },
@@ -348,7 +349,7 @@ module.exports = (function() {
 
       // Update matching documents
       collection.update(options, values, function(err, results) {
-        if(err) return cb(err);
+        if(err) return cb(utils.clarifyError(err));
         cb(null, results);
       });
     },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,8 @@
 var _ = require('lodash'),
     ObjectId = require('mongodb').ObjectID,
     MongoBinary = require('mongodb').Binary,
-    url = require('url');
+    url = require('url'),
+    WLValidationError = require('waterline/lib/waterline/error/WLValidationError');
 
 /**
  * ignore
@@ -161,3 +162,48 @@ exports.parseUrl = function parseUrl(config) {
 
   return config;
 };
+
+/**
+ * Return a WLValidationError if the provided error was
+ * caused by a unique constraint violation; otherwise,
+ * return the existing error
+ *
+ * @param {Error} err
+ * @return {Error}
+ * @api public
+ */
+
+exports.clarifyError = function clarifyError(err) {
+  // MongoDB duplicate key error code
+  if(err.code !== 11000) {
+    return err;
+  }
+
+  // Example errmsg: `E11000 duplicate key error index: db_name.model_name.$attribute_name_1 dup key: { : "value" }`
+  var model = capitalize(/: (.*?)\.(.*?)\./.exec(err.errmsg)[2]);
+  var fieldName = /\.\$(.*?)_\d+\s/.exec(err.errmsg)[1];
+  var value = JSON.parse(/{ : (".*") }/.exec(err.errmsg)[1].replace(/\\/g, ''));
+
+  var invalidAttributes = {};
+  invalidAttributes[fieldName] = [ { rule: 'unique', value: value } ];
+
+  var validationError = new WLValidationError({
+    invalidAttributes: invalidAttributes,
+    model: model,
+    originalError: err
+  });
+  validationError.code = 'E_UNIQUE';
+  return validationError;
+};
+
+/**
+ * Returns the string with its first letter capitalized
+ *
+ * @param {string} string
+ * @returns {{string}}
+ */
+function capitalize (string) {
+  return string.length > 1
+    ? string.charAt(0).toUpperCase() + string.substr(1)
+    : string.toUpperCase();
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -203,15 +203,3 @@ exports.clarifyError = function clarifyError(err) {
 
   return validationError;
 };
-
-/**
- * Returns the string with its first letter capitalized
- *
- * @param {string} string
- * @returns {{string}}
- */
-function capitalize (string) {
-  return string.length > 1
-    ? string.charAt(0).toUpperCase() + string.substr(1)
-    : string.toUpperCase();
-}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -174,27 +174,27 @@ exports.parseUrl = function parseUrl(config) {
  */
 
 exports.clarifyError = function clarifyError(err) {
-	// MongoDB duplicate key error code
-	if(err.code !== 11000) {
-		return err;
-	}
+  // MongoDB duplicate key error code
+  if(err.code !== 11000) {
+    return err;
+  }
 
-	// Example errmsg: `E11000 duplicate key error index: db_name.model_name.$attribute_name_1 dup key: { : "value" }`
-	var matches = /^E11000 duplicate key error index: .*?\.(.*?)\.\$(.*?)_\d+ dup key: { : (".*") }$/.exec(err.errmsg);
-	var model = capitalize(matches[1]); // actually name of collection! (model name is unknown)
-	var fieldName = matches[2]; // name of index (without _[digits] at the end)
-	var value = JSON.parse(matches[3]); // acts as a stripslashes on the quoted value
+  // Example errmsg: `E11000 duplicate key error index: db_name.model_name.$attribute_name_1 dup key: { : "value" }`
+  var matches = /^E11000 duplicate key error index: .*?\.(.*?)\.\$(.*?)_\d+ dup key: { : (".*") }$/.exec(err.errmsg);
+  var model = capitalize(matches[1]); // actually name of collection! (model name is unknown)
+  var fieldName = matches[2]; // name of index (without _[digits] at the end)
+  var value = JSON.parse(matches[3]); // acts as a stripslashes on the quoted value
 
-	var invalidAttributes = {};
-	invalidAttributes[fieldName] = [ { rule: 'unique', value: value } ];
+  var invalidAttributes = {};
+  invalidAttributes[fieldName] = [ { rule: 'unique', value: value } ];
 
-	var validationError = new WLValidationError({
-		invalidAttributes: invalidAttributes,
-		model: model,
-		originalError: err
-	});
-	validationError.code = 'E_UNIQUE';
-	return validationError;
+  var validationError = new WLValidationError({
+    invalidAttributes: invalidAttributes,
+    model: model,
+    originalError: err
+  });
+  validationError.code = 'E_UNIQUE';
+  return validationError;
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,8 +6,7 @@
 var _ = require('lodash'),
     ObjectId = require('mongodb').ObjectID,
     MongoBinary = require('mongodb').Binary,
-    url = require('url'),
-    WLValidationError = require('waterline/lib/waterline/error/WLValidationError');
+    url = require('url');
 
 /**
  * ignore
@@ -180,20 +179,23 @@ exports.clarifyError = function clarifyError(err) {
   }
 
   // Example errmsg: `E11000 duplicate key error index: db_name.model_name.$attribute_name_1 dup key: { : "value" }`
-  var matches = /^E11000 duplicate key error index: .*?\.(.*?)\.\$(.*?)_\d+ dup key: { : (".*") }$/.exec(err.errmsg);
-  var model = capitalize(matches[1]); // actually name of collection! (model name is unknown)
-  var fieldName = matches[2]; // name of index (without _[digits] at the end)
-  var value = JSON.parse(matches[3]); // acts as a stripslashes on the quoted value
+  var matches = /^E11000 duplicate key error index: .*?\..*?\.\$(.*?)_\d+ dup key: { : (".*") }$/.exec(err.errmsg);
+  var fieldName = matches[1]; // name of index (without _[digits] at the end)
+  var value = JSON.parse(matches[2]); // acts as a stripslashes on the quoted value
 
-  var invalidAttributes = {};
-  invalidAttributes[fieldName] = [ { rule: 'unique', value: value } ];
-
-  var validationError = new WLValidationError({
-    invalidAttributes: invalidAttributes,
-    model: model,
+  var validationError = {
+    code: 'E_UNIQUE',
+    invalidAttributes: {},
     originalError: err
-  });
-  validationError.code = 'E_UNIQUE';
+  };
+
+  validationError.invalidAttributes[fieldName] = [
+    {
+      rule: 'unique',
+      value: value
+    }
+  ];
+
   return validationError;
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -179,9 +179,14 @@ exports.clarifyError = function clarifyError(err) {
   }
 
   // Example errmsg: `E11000 duplicate key error index: db_name.model_name.$attribute_name_1 dup key: { : "value" }`
-  var matches = /^E11000 duplicate key error index: .*?\..*?\.\$(.*?)_\d+ dup key: { : (".*") }$/.exec(err.errmsg);
+  var matches = /^E11000 duplicate key error index: .*?\..*?\.\$(.*?)_\d+ dup key: { : (.*) }$/.exec(err.errmsg);
   var fieldName = matches[1]; // name of index (without _[digits] at the end)
-  var value = JSON.parse(matches[2]); // acts as a stripslashes on the quoted value
+  var value;
+  try {
+    value = JSON.parse(matches[2]); // attempt to convert the value to a primitive representation
+  } catch (x) {
+    value = matches[2]; // for non-serializable objects (e.g. ObjectId representations), return as-is
+  }
 
   var validationError = {
     code: 'E_UNIQUE',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -174,26 +174,27 @@ exports.parseUrl = function parseUrl(config) {
  */
 
 exports.clarifyError = function clarifyError(err) {
-  // MongoDB duplicate key error code
-  if(err.code !== 11000) {
-    return err;
-  }
+	// MongoDB duplicate key error code
+	if(err.code !== 11000) {
+		return err;
+	}
 
-  // Example errmsg: `E11000 duplicate key error index: db_name.model_name.$attribute_name_1 dup key: { : "value" }`
-  var model = capitalize(/: (.*?)\.(.*?)\./.exec(err.errmsg)[2]);
-  var fieldName = /\.\$(.*?)_\d+\s/.exec(err.errmsg)[1];
-  var value = JSON.parse(/{ : (".*") }/.exec(err.errmsg)[1].replace(/\\/g, ''));
+	// Example errmsg: `E11000 duplicate key error index: db_name.model_name.$attribute_name_1 dup key: { : "value" }`
+	var matches = /^E11000 duplicate key error index: .*?\.(.*?)\.\$(.*?)_\d+ dup key: { : (".*") }$/.exec(err.errmsg);
+	var model = capitalize(matches[1]); // actually name of collection! (model name is unknown)
+	var fieldName = matches[2]; // name of index (without _[digits] at the end)
+	var value = JSON.parse(matches[3]); // acts as a stripslashes on the quoted value
 
-  var invalidAttributes = {};
-  invalidAttributes[fieldName] = [ { rule: 'unique', value: value } ];
+	var invalidAttributes = {};
+	invalidAttributes[fieldName] = [ { rule: 'unique', value: value } ];
 
-  var validationError = new WLValidationError({
-    invalidAttributes: invalidAttributes,
-    model: model,
-    originalError: err
-  });
-  validationError.code = 'E_UNIQUE';
-  return validationError;
+	var validationError = new WLValidationError({
+		invalidAttributes: invalidAttributes,
+		model: model,
+		originalError: err
+	});
+	validationError.code = 'E_UNIQUE';
+	return validationError;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-mongo",
-  "version": "0.11.2.1",
+  "version": "0.11.2",
   "description": "Mongo DB adapter for Sails.js",
   "main": "./lib/adapter.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-mongo",
-  "version": "0.11.2",
+  "version": "0.11.2.1",
   "description": "Mongo DB adapter for Sails.js",
   "main": "./lib/adapter.js",
   "scripts": {
@@ -44,6 +44,7 @@
     "async": "~0.8.0",
     "lodash": "~2.4.1",
     "mongodb": "^2.0.27",
+    "waterline": "^0.10.26",
     "waterline-cursor": "~0.0.5",
     "waterline-errors": "~0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "async": "~0.8.0",
     "lodash": "~2.4.1",
     "mongodb": "^2.0.27",
-    "waterline": "^0.10.26",
     "waterline-cursor": "~0.0.5",
     "waterline-errors": "~0.10.0"
   },

--- a/test/unit/utils.clarifyError.test.js
+++ b/test/unit/utils.clarifyError.test.js
@@ -60,6 +60,28 @@ describe('clarifyError', function () {
     assert.strictEqual(validationError.invalidAttributes['name'][0].value, '"this" here \\is\\ a "test"');
     assert.strictEqual(validationError.originalError, err);
   });
+
+  it('handles non-string values correctly', function () {
+    var err = createError('test', 'collection', 'name', 360.25);
+    var validationError = clarifyError(err);
+
+    assert.strictEqual(validationError.code, 'E_UNIQUE');
+    assert(validationError.invalidAttributes['name'] && validationError.invalidAttributes['name'][0]);
+    assert.strictEqual(validationError.invalidAttributes['name'][0].rule, 'unique');
+    assert.strictEqual(validationError.invalidAttributes['name'][0].value, 360.25);
+    assert.strictEqual(validationError.originalError, err);
+  });
+
+  it('uses the string representation of non-JSON-serializable values', function () {
+    var err = createError('test', 'collection', 'name', 'ObjectId("507f191e810c19729de860ea")');
+    var validationError = clarifyError(err);
+
+    assert.strictEqual(validationError.code, 'E_UNIQUE');
+    assert(validationError.invalidAttributes['name'] && validationError.invalidAttributes['name'][0]);
+    assert.strictEqual(validationError.invalidAttributes['name'][0].rule, 'unique');
+    assert.strictEqual(validationError.invalidAttributes['name'][0].value, 'ObjectId("507f191e810c19729de860ea")');
+    assert.strictEqual(validationError.originalError, err);
+  });
 });
 
 /**

--- a/test/unit/utils.clarifyError.test.js
+++ b/test/unit/utils.clarifyError.test.js
@@ -1,0 +1,83 @@
+var assert = require('assert');
+var clarifyError = require('../../lib/utils').clarifyError;
+var WLValidationError = require('waterline/lib/waterline/error/WLValidationError');
+
+describe('clarifyError', function () {
+  it('returns the original error object if it does not have the proper error code', function () {
+    var err = new Error();
+    err.code = 9001;
+
+    var validationError = clarifyError(err);
+    assert.strictEqual(validationError, err);
+  });
+
+  it('returns a WLValidationError if passed a MongoDB duplicate key error', function () {
+    var err = createError('test', 'collection', 'name', 'test');
+    var validationError = clarifyError(err);
+
+    assert(validationError instanceof WLValidationError);
+  });
+
+  it('extracts properties from the error message and populates the WLValidationError', function () {
+    var err = createError('test', 'collection', 'name', 'test');
+    var validationError = clarifyError(err);
+
+    assert.strictEqual(validationError.code, 'E_UNIQUE');
+    assert.strictEqual(validationError.model, 'Collection');
+    assert(validationError.invalidAttributes['name'] && validationError.invalidAttributes['name'][0]);
+    assert.strictEqual(validationError.invalidAttributes['name'][0].rule, 'unique');
+    assert.strictEqual(validationError.invalidAttributes['name'][0].value, 'test');
+    assert.strictEqual(validationError.originalError, err);
+  });
+
+  it('handles underscores in database names, collections, and attributes correctly', function () {
+    var err = createError('test_db', 'my_collection_name', 'my_field_name', 'test_value');
+    var validationError = clarifyError(err);
+
+    assert.strictEqual(validationError.code, 'E_UNIQUE');
+    assert.strictEqual(validationError.model, 'My_collection_name');
+    assert(validationError.invalidAttributes['my_field_name'] && validationError.invalidAttributes['my_field_name'][0]);
+    assert.strictEqual(validationError.invalidAttributes['my_field_name'][0].rule, 'unique');
+    assert.strictEqual(validationError.invalidAttributes['my_field_name'][0].value, 'test_value');
+    assert.strictEqual(validationError.originalError, err);
+  });
+
+  it('handles attributes ending in _[digits] correctly', function () {
+    var err = createError('test', 'collection', 'name_123', 'test');
+    var validationError = clarifyError(err);
+
+    assert.strictEqual(validationError.code, 'E_UNIQUE');
+    assert.strictEqual(validationError.model, 'Collection');
+    assert(validationError.invalidAttributes['name_123'] && validationError.invalidAttributes['name_123'][0]);
+    assert.strictEqual(validationError.invalidAttributes['name_123'][0].rule, 'unique');
+    assert.strictEqual(validationError.invalidAttributes['name_123'][0].value, 'test');
+    assert.strictEqual(validationError.originalError, err);
+  });
+
+  it('handles values with escaped quotation marks correctly', function () {
+    var err = createError('test', 'collection', 'name', '"this" here \\is\\ a "test"');
+    var validationError = clarifyError(err);
+
+    assert.strictEqual(validationError.code, 'E_UNIQUE');
+    assert.strictEqual(validationError.model, 'Collection');
+    assert(validationError.invalidAttributes['name'] && validationError.invalidAttributes['name'][0]);
+    assert.strictEqual(validationError.invalidAttributes['name'][0].rule, 'unique');
+    assert.strictEqual(validationError.invalidAttributes['name'][0].value, '"this" here \\is\\ a "test"');
+    assert.strictEqual(validationError.originalError, err);
+  });
+});
+
+/**
+ * Generates an error object that emulates a MongoDB duplicate key error
+ * @param {string} database
+ * @param {string} collection
+ * @param {string} attribute
+ * @param {string} value
+ * @returns {object} Error object with code and errmsg
+ */
+function createError (database, collection, attribute, value) {
+  return {
+    code: 11000,
+    errmsg: 'E11000 duplicate key error index: ' + database + '.' + collection + '.' + '$' + attribute + '_42 dup key: { : ' + JSON.stringify(value) + ' }'
+  };
+}

--- a/test/unit/utils.clarifyError.test.js
+++ b/test/unit/utils.clarifyError.test.js
@@ -1,6 +1,5 @@
 var assert = require('assert');
 var clarifyError = require('../../lib/utils').clarifyError;
-var WLValidationError = require('waterline/lib/waterline/error/WLValidationError');
 
 describe('clarifyError', function () {
   it('returns the original error object if it does not have the proper error code', function () {
@@ -11,19 +10,18 @@ describe('clarifyError', function () {
     assert.strictEqual(validationError, err);
   });
 
-  it('returns a WLValidationError if passed a MongoDB duplicate key error', function () {
+  it('returns a validation error if passed a MongoDB duplicate key error', function () {
     var err = createError('test', 'collection', 'name', 'test');
     var validationError = clarifyError(err);
 
-    assert(validationError instanceof WLValidationError);
+    assert(validationError.code === 'E_UNIQUE');
   });
 
-  it('extracts properties from the error message and populates the WLValidationError', function () {
+  it('extracts properties from the error message and populates the validation error', function () {
     var err = createError('test', 'collection', 'name', 'test');
     var validationError = clarifyError(err);
 
     assert.strictEqual(validationError.code, 'E_UNIQUE');
-    assert.strictEqual(validationError.model, 'Collection');
     assert(validationError.invalidAttributes['name'] && validationError.invalidAttributes['name'][0]);
     assert.strictEqual(validationError.invalidAttributes['name'][0].rule, 'unique');
     assert.strictEqual(validationError.invalidAttributes['name'][0].value, 'test');
@@ -35,7 +33,6 @@ describe('clarifyError', function () {
     var validationError = clarifyError(err);
 
     assert.strictEqual(validationError.code, 'E_UNIQUE');
-    assert.strictEqual(validationError.model, 'My_collection_name');
     assert(validationError.invalidAttributes['my_field_name'] && validationError.invalidAttributes['my_field_name'][0]);
     assert.strictEqual(validationError.invalidAttributes['my_field_name'][0].rule, 'unique');
     assert.strictEqual(validationError.invalidAttributes['my_field_name'][0].value, 'test_value');
@@ -47,7 +44,6 @@ describe('clarifyError', function () {
     var validationError = clarifyError(err);
 
     assert.strictEqual(validationError.code, 'E_UNIQUE');
-    assert.strictEqual(validationError.model, 'Collection');
     assert(validationError.invalidAttributes['name_123'] && validationError.invalidAttributes['name_123'][0]);
     assert.strictEqual(validationError.invalidAttributes['name_123'][0].rule, 'unique');
     assert.strictEqual(validationError.invalidAttributes['name_123'][0].value, 'test');
@@ -59,7 +55,6 @@ describe('clarifyError', function () {
     var validationError = clarifyError(err);
 
     assert.strictEqual(validationError.code, 'E_UNIQUE');
-    assert.strictEqual(validationError.model, 'Collection');
     assert(validationError.invalidAttributes['name'] && validationError.invalidAttributes['name'][0]);
     assert.strictEqual(validationError.invalidAttributes['name'][0].rule, 'unique');
     assert.strictEqual(validationError.invalidAttributes['name'][0].value, '"this" here \\is\\ a "test"');


### PR DESCRIPTION
When the Mongo driver responds with an error during insertion and updates, intercept the error, examine the message, and, if the error is a result of a duplicate key constraint violation, produce a `WLValidationError`.

This is consistent with the implementations for the [sails-mysql](https://github.com/balderdashy/sails-mysql/blob/master/lib/adapter.js#L1201) and [sails-postgresql](https://github.com/balderdashy/sails-postgresql/blob/master/lib/adapter.js#L1215) adapters.