### PR TITLE
fixed: return correct id when creating a model with a static id

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,10 +39,8 @@ exports.object.hasOwnProperty = function(obj, prop) {
 exports._rewriteIds = function(model, schema) {
   if (hop.call(model, '_id')) {
     // change id to string only if it's necessary
-    if (typeof model._id === 'object' && model._id._bsontype === 'ObjectID')
-      model.id = (new ObjectId(model._id.id)).toString();
     if (typeof model._id === 'object')
-      model.id = model._id.toString();
+      model.id = model._id._bsontype === 'ObjectID' ? (new ObjectId(model._id.id)).toString() : model._id.toString();
     else
       model.id = model._id;
     delete model._id;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,6 +39,8 @@ exports.object.hasOwnProperty = function(obj, prop) {
 exports._rewriteIds = function(model, schema) {
   if (hop.call(model, '_id')) {
     // change id to string only if it's necessary
+    if (typeof model._id === 'object' && model._id._bsontype === 'ObjectID')
+      model.id = (new ObjectId(model._id.id)).toString();
     if (typeof model._id === 'object')
       model.id = model._id.toString();
     else

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,7 @@ exports._rewriteIds = function(model, schema) {
   if (hop.call(model, '_id')) {
     // change id to string only if it's necessary
     if (typeof model._id === 'object')
-      model.id = model._id._bsontype === 'ObjectID' ? (new ObjectId(model._id.id)).toString() : model._id.toString();
+      model.id = model._id._bsontype === 'ObjectID' ? (new ObjectId(model._id.id)).toString() : model._id.toString(); // check for type (Object vs. ObjectID)
     else
       model.id = model._id;
     delete model._id;


### PR DESCRIPTION
When sails-mongo creates a new model with a static id, it creates a MongoDB ObjectID for the _id property and passes it to MongoDB, however when this comes back from MongoDB it is returned as a generic JS object with properties _bsontype (= "ObjectID") and a binary value as the id.  

When sails-mongo converts this back to the "id" property for the model, it runs the toString() method, and in this case that will become "[Object object]" (not the correct string value for the id).

This fix looks for the _bsontype property when the _id value is an object and will convert it to the correct string representation.