### PR TITLE
Update connection.js Re: #323

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -97,6 +97,10 @@ Connection.prototype._buildConnection = function _buildConnection(cb) {
   connectionOptions.server = {
     readPreference: this.config.readPreference,
     ssl: this.config.ssl,
+    sslValidate: this.config.sslValidate,
+    sslCA: this.config.sslCA,
+    sslCert: this.config.sslCert,
+    sslKey: this.config.sslKey,
     poolSize: this.config.poolSize,
     socketOptions: this.config.socketOptions,
     auto_reconnect: this.config.auto_reconnect,


### PR DESCRIPTION
Adding extra SSL configuration parameters for underlying mongodb driver to take advantage of so SSL certs/keys can be presented to mongo server and cert retrieved from mongo server can be compared/validated against a CA.