### PR TITLE
use validator to skip parsing mongoId to like query ,use direct query instead

### DIFF
--- a/lib/query/index.js
+++ b/lib/query/index.js
@@ -7,6 +7,7 @@ var _ = require('lodash'),
     ObjectId = require('mongodb').ObjectID,
     Aggregate = require('./aggregate'),
     utils = require('../utils'),
+    validator = require('validator'),
     hop = utils.object.hasOwnProperty;
 
 /**
@@ -364,10 +365,13 @@ Query.prototype.parseValue = function parseValue(field, modifier, val) {
     if (omitRegExModifiers.indexOf(modifier) > -1) {
       return val;
     }
-    // Replace Percent Signs, work in a case insensitive fashion by default
-    val = utils.caseInsensitive(val);
-    val = val.replace(/%/g, '.*');
-    val = new RegExp('^' + val + '$', 'i');
+
+    if(!validator.isMongoId(val)){//only if it's not mongodbID, for most of case usage would like: user.find('56173df732776c64852f8c91')
+      // Replace Percent Signs, work in a case insensitive fashion by default
+      val = utils.caseInsensitive(val);
+      val = val.replace(/%/g, '.*');
+      val = new RegExp('^' + val + '$', 'i');
+    }
     return val;
   }
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "async": "~1.4.2",
     "lodash": "~3.10.0",
     "mongodb": "^2.0.42",
+    "validator": "^4.1.0",
     "waterline-cursor": "~0.0.6",
     "waterline-errors": "~0.10.0"
   },

--- a/test/unit/query/adapter.query.test.js
+++ b/test/unit/query/adapter.query.test.js
@@ -99,6 +99,17 @@ describe('Query', function () {
         assert(_.isEqual(actual['user'].toString(), expect['user'].toString()));
       });
 
+      it('should accept objectid string', function () {
+        var _id = new ObjectID();
+        var where = {
+          user: '' + new ObjectID(_id)
+        };
+
+        var Q = new Query({ where: where }, { user: 'objectid' });
+        var actual = Q.criteria.where;
+        assert(_.isEqual(typeof actual['user'], 'string'));
+      });
+
       it('should accept objectid in Not Pair', function () {
         var _id = new ObjectID();
         var where = {


### PR DESCRIPTION
for the case : 

    User.find({id:'56173df732776c64852f8c91'})

this would parse to query in the following (in mongodb.log):

    query: { _id: ObjectId('56173804889cc73f952b7abd') } 

instead of :

     query: { _id: ObjectId(/^56173804889cc73f952b7abd$/i) } 
 
This change improve  CRUD speed