### PR TITLE
connection constructor: fix obscure case when both error and db are falsey

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -23,6 +23,7 @@ var Connection = module.exports = function Connection(config, cb) {
   // Build Database connection
   this._buildConnection(function(err, db) {
     if(err) return cb(err);
+    if(!db) return cb(new Error('no db object'));
 
     // Store the DB object
     self.db = db;


### PR DESCRIPTION
This tries to fix https://github.com/balderdashy/sails-mongo/issues/352

The db object assigned to connection key in (1) could actually have
it's field db assigned to undefined in (2), because the db object comes
from (5) (passed through (3), (4)) and it is actually is checked to be
undefined in (6), as returned from (5).

### (1)

    connections[connection.identity].connection = db;

https://github.com/balderdashy/sails-mongo/blob/659f430eaf1b7d2402d7762afaaf6bb78346d913/lib/adapter.js#L108

### (2)

    self.db = db;

https://github.com/balderdashy/sails-mongo/blob/659f430eaf1b7d2402d7762afaaf6bb78346d913/lib/connection.js#L28

### (3)

    this._buildConnection(function(err, db) {

https://github.com/balderdashy/sails-mongo/blob/659f430eaf1b7d2402d7762afaaf6bb78346d913/lib/connection.js#L24

### (4)

    MongoClient.connect(connectionString, connectionOptions, cb);

https://github.com/balderdashy/sails-mongo/blob/659f430eaf1b7d2402d7762afaaf6bb78346d913/lib/connection.js#L153

### (5)

    db.open(function(err, db){

https://github.com/mongodb/node-mongodb-native/blob/9a70b50efac27878c49641efef13a91a9544677d/lib/mongo_client.js#L400

### (6)

    if(db) db.close();

https://github.com/mongodb/node-mongodb-native/blob/9a70b50efac27878c49641efef13a91a9544677d/lib/mongo_client.js#L457