### PR TITLE
Fix issue when there are no connections at startup

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -135,7 +135,7 @@ module.exports = (function() {
         var dbs = _.pluck(_.pluck(_.values(connections), 'connection'), 'db');
         connections = {};
         return async.each(dbs, function (db, onClosed) {
-          db.close(onClosed);
+          db && db.close(onClosed);
         }, cb);
       }
       if(!connections[conn]) return cb();


### PR DESCRIPTION
When I start Sails and there are no available Mongo servers to connect to, the app crashes with the following stack trace:

```
error: A hook (`orm`) failed to load!

TypeError: Cannot read property 'close' of undefined
    at /app/node_modules/sails-mongo/lib/adapter.js:138:13
    at /app/node_modules/async/lib/async.js:187:20
    at /app/node_modules/async/lib/async.js:239:13
    at _each (/app/node_modules/async/lib/async.js:82:13)
    at _arrayEach (/app/node_modules/async/lib/async.js:91:13)
    at Object.async.forEachOf.async.eachOf (/app/node_modules/async/lib/async.js:238:9)
    at Object.async.forEach.async.each (/app/node_modules/async/lib/async.js:215:22)
    at /app/node_modules/sails/node_modules/async/lib/async.js:122:13
    at Object.module.exports.adapter.teardown (/app/node_modules/sails-mongo/lib/adapter.js:137:22)
    at /app/node_modules/sails/lib/hooks/orm/index.js:244:19
    at Sails.hook.teardown (/app/node_modules/sails/lib/hooks/orm/index.js:241:13)
    at _each (/app/node_modules/sails/node_modules/async/lib/async.js:46:13)
    at Object.async.each (/app/node_modules/sails/node_modules/async/lib/async.js:121:9)
    at Sails.g (events.js:260:16)
    at emitNone (events.js:67:13)

    at Sails.emit (events.js:166:7)
```

This PR merely checks for the presence of the `db` object and only allows the `.close()` call if the variable is defined. I did not take the time to properly investigate the issue so perhaps there would be a better way to fix this.

Thanks!