### PR TITLE
Don't stringify IDs when not bson ObjectID

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,7 +39,7 @@ exports.object.hasOwnProperty = function(obj, prop) {
 exports._rewriteIds = function(model, schema) {
   if (hop.call(model, '_id')) {
     // change id to string only if it's necessary
-    if (typeof model._id === 'object')
+    if (typeof model._id === 'object' && model._id._bsontype)
       model.id = model._id.toString();
     else
       model.id = model._id;


### PR DESCRIPTION
MapReduces results are like : 
```
{
  '_id': {
    'foo': "bar",
    ...
  },
  'values':{
    'bar': "foo",
    ...
  }
```

So when they're stringified, sails-mongo returned "[Object object]" string. Now fixed.