### PR TITLE
Change deserialization method to not block event loop

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -95,7 +95,10 @@ Collection.prototype.find = function find(criteria, cb) {
   // Run Normal Query on collection
   collection.find(where, query.select, queryOptions).toArray(function(err, docs) {
     if(err) return cb(err);
-    cb(null, utils.normalizeResults(docs, self.schema));
+    utils.normalizeResults(docs, self.schema)
+      .then(function(models) {
+        cb(null, models);
+      });
   });
 };
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -95,10 +95,7 @@ Collection.prototype.find = function find(criteria, cb) {
   // Run Normal Query on collection
   collection.find(where, query.select, queryOptions).toArray(function(err, docs) {
     if(err) return cb(err);
-    utils.normalizeResults(docs, self.schema)
-      .then(function(models) {
-        cb(null, models);
-      });
+    utils.normalizeResults(docs, self.schema, cb)
   });
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,8 @@
 var _ = require('lodash'),
     ObjectId = require('mongodb').ObjectID,
     MongoBinary = require('mongodb').Binary,
-    url = require('url');
+    url = require('url'),
+    compute = require('background-compute');
 
 /**
  * ignore
@@ -83,7 +84,7 @@ exports.rewriteIds = function rewriteIds(models, schema) {
  */
 
 exports.normalizeResults = function normalizeResults(models, schema) {
-  var _models = models.map(function (model) {
+  return compute.parallel.map(models, 8, function(model) {
     var _model = exports._rewriteIds(model, schema);
     Object.keys(_model).forEach(function (key) {
       if (model[key] instanceof MongoBinary && _.has(_model[key], 'buffer')) {
@@ -92,7 +93,6 @@ exports.normalizeResults = function normalizeResults(models, schema) {
     });
     return _model;
   });
-  return _models;
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -83,7 +83,7 @@ exports.rewriteIds = function rewriteIds(models, schema) {
  * @api public
  */
 
-exports.normalizeResults = function normalizeResults(models, schema) {
+exports.normalizeResults = function normalizeResults(models, schema, cb) {
   return compute.parallel.map(models, 8, function(model) {
     var _model = exports._rewriteIds(model, schema);
     Object.keys(_model).forEach(function (key) {
@@ -92,7 +92,7 @@ exports.normalizeResults = function normalizeResults(models, schema) {
       }
     });
     return _model;
-  });
+  }, cb);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "async": "~1.4.2",
+    "background-compute": "0.0.1",
     "lodash": "~3.10.0",
     "mongodb": "^2.0.42",
     "validator": "^4.1.0",


### PR DESCRIPTION
Currently, the deserialization in collection.find operates synchronously. Large data sets and/or models with several properties will delay the event loop. 

This proposed change leverages node's timing API. Instead of completing all deserialization during one tick, this will deserialize a fixed number each tick and invoke the callback function when all documents have been deserialized.

Here is the library I am using to accomplish this: https://github.com/stweedie/node-background-compute 