### PR TITLE
feat(count): Allow to pass options for the Colletion#count()

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -319,7 +319,10 @@ Collection.prototype.count = function count(criteria, cb) {
     return cb(err);
   }
 
-  this.connection.db.collection(this.identity).count(query.criteria.where, function(err, count) {
+  var where = query.criteria.where || {};
+  var queryOptions = _.omit(query.criteria, 'where');
+
+  this.connection.db.collection(this.identity).count(where, queryOptions, function(err, count) {
     if (err) return cb(err);
     cb(null, count);
   });


### PR DESCRIPTION
Based on http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#count you can pass some options to the Collection#count().

This patch should allow these options.

I specially need support for `hint`.
