### PR TITLE
feat(aggregate): Allow $skip and $limit when using Collection#aggregate()

### DIFF
--- a/lib/collection.js
+++ b/lib/collection.js
@@ -73,10 +73,18 @@ Collection.prototype.find = function find(criteria, cb) {
 
   // Check for aggregate query
   if(query.aggregate) {
-    var aggregate = [
-      { '$match': query.criteria.where || {} },
-      { '$group': query.aggregateGroup }
-    ];
+    var aggregate = [];
+
+    if (criteria.skip) {
+      aggregate.push({ '$skip': criteria.skip });
+    }
+
+    if (criteria.limit) {
+      aggregate.push({ '$limit': criteria.limit });
+    }
+
+    aggregate.push({ '$match': query.criteria.where || {} });
+    aggregate.push({ '$group': query.aggregateGroup });
 
     return collection.aggregate(aggregate, function(err, results) {
 


### PR DESCRIPTION
Respect `limit` and `skip` of the query when using Collection#aggregate().