### PR TITLE
Use pre initialized mongo connection

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -89,26 +89,29 @@ module.exports = (function() {
      * Will open up a new connection using the configuration provided and store the DB
      * object to run commands off of. This creates a new pool for each connection config.
      *
-     * @param {Object} connection
+     * @param {Object} passedConnectionConfiguration
      * @param {Object} collections
-     * @param {Function} callback
+     * @param {Function} cb
      */
 
-    registerConnection: function(connection, collections, cb) {
-      if(!connection.identity) return cb(Errors.IdentityMissing);
-      if(connections[connection.identity]) return cb(Errors.IdentityDuplicate);
+    registerConnection: function(passedConnectionConfiguration, collections, cb) {
+      var connectionConfiguration = passedConnectionConfiguration || {};
+      var identity = connectionConfiguration.identity;
+
+      if(!identity) return cb(Errors.IdentityMissing);
+      if(connections[identity]) return cb(Errors.IdentityDuplicate);
 
       // Merging default options
-      connection = _.defaults(connection, this.defaults);
+      connectionConfiguration = _.defaults(connectionConfiguration, this.defaults);
 
       // Store the connection
-      connections[connection.identity] = {
-        config: connection,
+      connections[identity] = {
+        config: connectionConfiguration,
         collections: {}
       };
 
       // Create a new active connection
-      new Connection(connection, function(_err, db) {
+      new Connection(connectionConfiguration, function(_err, db) {
 
         if(_err) {
           return cb((function _createError(){
@@ -118,11 +121,11 @@ module.exports = (function() {
             return err;
           })());
         }
-        connections[connection.identity].connection = db;
+        connections[identity].connection = db;
 
         // Build up a registry of collections
         Object.keys(collections).forEach(function(key) {
-          connections[connection.identity].collections[key] = new Collection(collections[key], db);
+          connections[identity].collections[key] = new Collection(collections[key], db);
         });
 
         cb();

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -17,19 +17,27 @@ var async = require('async'),
 var Connection = module.exports = function Connection(config, cb) {
   var self = this;
 
+  function resolveCallback (db) {
+    // Store the DB object
+    self.db = db;
+
+    // Return the connection
+    cb(null, self);
+  }
+
   // Hold the config object
   this.config = config || {};
+
+  if (config.db) {
+    return resolveCallback(config.db);
+  }
 
   // Build Database connection
   this._buildConnection(function(err, db) {
     if(err) return cb(err);
     if(!db) return cb(new Error('no db object'));
 
-    // Store the DB object
-    self.db = db;
-
-    // Return the connection
-    cb(null, self);
+    resolveCallback(db);
   });
 };
 

--- a/test/unit/connection.js
+++ b/test/unit/connection.js
@@ -1,0 +1,40 @@
+var Connection = require('../../lib/connection'),
+  Config = require('../support/config'),
+  mongodb = require('mongodb'),
+  assert = require('assert'),
+  _ = require('lodash'),
+  MongoClient = mongodb.MongoClient;
+
+describe('connection', function () {
+    describe('when mongo connection object is passed', function () {
+        var expectedDbConnection;
+
+        before(function (done) {
+            var connectionString = [
+                'mongodb://',
+                Config.host,
+                ':' + Config.port,
+                '/' + Config.database
+            ].join('');
+
+            MongoClient.connect(connectionString, function (err, db) {
+                expectedDbConnection = db;
+                done(err);
+            });
+        });
+
+        after(function () {
+            return expectedDbConnection.close();
+        });
+
+        it('should use the passed mongo connection object', function (done) {
+            var passedConfig = _.extend({}, Config);
+            passedConfig.db = expectedDbConnection;
+
+            new Connection(passedConfig, function (_err, db) {
+                assert(db.db === expectedDbConnection);
+                done(_err);
+            });
+        });
+    });
+});


### PR DESCRIPTION
In our company we want to migrate from using mongoose to using sails. We cannot migrate everything at once (time pressure), we want to run both at the same time until transition is fully done. Because connection to the mongo is already instantiated with mongoose we just want to use the same connection also with sails.

This changes do not break any existing functionality it only ads the ability to use already instantiated mongodb connection. Maybe someone else finds this usefull.
