### PR TITLE
Fixes reconnect issues with MongoDB, defaults now to 30 seconds.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -66,7 +66,8 @@ module.exports = (function() {
       },
       auto_reconnect: true,
       disableDriverBSONSizeCheck: false,
-      reconnectInterval: 200,
+      reconnectTries: 30, // defaults to mongodb recommended settings
+      reconnectInterval: 1000, // defaults to mongodb recommended settings
 
 
       // Waterline NEXT

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -105,7 +105,8 @@ Connection.prototype._buildConnection = function _buildConnection(cb) {
     socketOptions: this.config.socketOptions,
     autoReconnect: this.config.auto_reconnect,
     disableDriverBSONSizeCheck: this.config.disableDriverBSONSizeCheck,
-    reconnectInterval: this.config.reconnectInterval
+    reconnectInterval: this.config.reconnectInterval,
+    reconnectTries: this.config.reconnectTries
   };
 
   // Build up options used for creating a Database instance


### PR DESCRIPTION
Fixes reconnect issues with MongoDB, defaults now to 30 seconds.
It also adds reconnectTries, so you can configure both reconnectInterval and reconnectTries.


@nickerickson, @mudrekh and I found the issue about MongoDB not reconnecting. Basically, sails-mongo/lib/adapter.js sets reconnectInterval=200 and by default reconnectTries is 30, so, it just tries for 6 seconds. If the delay is more than 6 seconds, it will not retry.