### PR TITLE
Update readme to reflect that is is now possible to sort by id.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@
 
 Waterline adapter for MongoDB.
 
-> **Heads up**
->
-> `sails-mongo` maps the logical `id` attribute to the required `_id` physical-layer mongo id.
-> In the current version of `sails-mongo`, you **should not** sort by `id`.
-
 ## Installation
 
 Install from NPM.


### PR DESCRIPTION
After digging through the source a bit, it seems this problem has already been addressed. See ./lib/query/index.js, line 403. It would be nice to update the readme, so it does not confuse other people. 
