### PR TITLE
Fix group aggregate field name cannot contain dot mongo error

### DIFF
--- a/lib/query/aggregate.js
+++ b/lib/query/aggregate.js
@@ -50,25 +50,25 @@ Aggregate.prototype.build = function build(options) {
   // Build up the group for the $group aggregation phase
   if(Array.isArray(options.sum)) {
     options.sum.forEach(function(opt) {
-      self.group[opt] = { '$sum': '$' + opt };
+      self.group[opt.replace(/\./g,"-")] = { '$sum': '$' + opt };
     });
   }
 
   if(Array.isArray(options.average)) {
     options.average.forEach(function(opt) {
-      self.group[opt] = { '$avg': '$' + opt };
+      self.group[opt.replace(/\./g,"-")] = { '$avg': '$' + opt };
     });
   }
 
   if(Array.isArray(options.min)) {
     options.min.forEach(function(opt) {
-      self.group[opt] = { '$min': '$' + opt };
+      self.group[opt.replace(/\./g,"-")] = { '$min': '$' + opt };
     });
   }
 
   if(Array.isArray(options.max)) {
     options.max.forEach(function(opt) {
-      self.group[opt] = { '$max': '$' + opt };
+      self.group[opt.replace(/\./g,"-")] = { '$max': '$' + opt };
     });
   }
 };


### PR DESCRIPTION
If the field to be summed/averaged/counted/etc.. is a on a sub-document
then the group aggregate field name will contain a dot and mongoDb does
not allow this, chose to replace by dash.
