### PR TITLE
Return 0 if there are no documents to sum

### DIFF
--- a/lib/private/machines/sum-records.js
+++ b/lib/private/machines/sum-records.js
@@ -77,7 +77,8 @@ module.exports = {
     ], function aggregateCb(err, nativeResult) {
       if (err) { return exits.error(err); }
 
-      var sum = _.first(nativeResult).sum;
+      var sum = 0;
+      if (_.first(nativeResult)) { sum = _.first(nativeResult).sum; }
       return exits.success(sum);
     });//</ db.collection(...).aggregate() >
   }

--- a/lib/private/machines/sum-records.js
+++ b/lib/private/machines/sum-records.js
@@ -77,7 +77,7 @@ module.exports = {
     ], function aggregateCb(err, nativeResult) {
       if (err) { return exits.error(err); }
 
-      var sum = 0;
+      var sum = null;
       if (_.first(nativeResult)) { sum = _.first(nativeResult).sum; }
       return exits.success(sum);
     });//</ db.collection(...).aggregate() >


### PR DESCRIPTION
Hi guys, I found this bug in the code using the latest version of sails-mongo with the sum query:

```
/Users/josebalegarreta/Projects/kuaderno/teacher/node_modules/sails-mongo/node_modules/mongodb/lib/utils.js:123
    process.nextTick(function() { throw err; });
                                  ^

TypeError: Cannot read property 'sum' of undefined
    at aggregateCb (/Users/josebalegarreta/Projects/kuaderno/teacher/node_modules/sails-mongo/lib/private/machines/sum-records.js:80:38)
```
Basically if I do this query: `Connections.sum('time').where({student: student.id}).exec(next);` and if there're no connections that match that where condition, the mongo query result is an empty array instead of something like this: `[{_id: 'time', sum: 100}]`. So this part of code: `_.first(nativeResult).sum` crashes.

With this patch, if there no records to sum, the exit is 0 ([this is mongo's normal behavior](https://docs.mongodb.com/manual/reference/operator/aggregation/sum/#behavior))

Thanks!

