### PR TITLE
Skip running native `.sort()` if there's nothing to sort.

### DIFF
--- a/lib/private/machines/find-records.js
+++ b/lib/private/machines/find-records.js
@@ -88,7 +88,10 @@ module.exports = {
     var mongoDeferred;
     try {
       assert(_.isNumber(s3q.criteria.limit), 'At this point, the limit should always be a number, but instead it is `'+s3q.criteria.limit+'`.  If you are seeing this message, there is probably a bug somewhere in your version of Waterline core.');
-      mongoDeferred = mongoCollection.find(mongoWhere).limit(s3q.criteria.limit).sort(mongoSort);
+      mongoDeferred = mongoCollection.find(mongoWhere).limit(s3q.criteria.limit);
+      if (mongoSort.length) {
+        mongoDeferred = mongoDeferred.sort(mongoSort);
+      }
     } catch (err) { return exits.error(err); }
 
     // Add in `select` if necessary.


### PR DESCRIPTION
This is probably the same as `.sort([])` -- testing indicates as much -- but just in case it's not, and for the purposes of fixing https://github.com/balderdashy/sails/issues/4105, no harm in removing the native sort method call altogether in these cases.

refs https://github.com/balderdashy/sails/issues/4105