### PR TITLE
Adding missing appname to config whitelist

### DIFF
--- a/lib/private/constants/config-whitelist.constant.js
+++ b/lib/private/constants/config-whitelist.constant.js
@@ -19,6 +19,6 @@ module.exports = [
   'acceptableLatencyMS', 'connectWithNoPrimary', 'authSource', 'w',
   'wtimeout', 'j', 'forceServerObjectId', 'serializeFunctions',
   'ignoreUndefined', 'raw', 'promoteLongs', 'bufferMaxEntries',
-  'readPreference', 'pkFactory', 'readConcern'
+  'readPreference', 'pkFactory', 'readConcern', 'appname'
 
 ];


### PR DESCRIPTION
Adding appname to config whitelist as shown on http://mongodb.github.io/node-mongodb-native/2.2/reference/connecting/connection-settings/

It is really important for us to be able to see what apps are using what connections by running `db.currentOp(true).inprog` on Mongo. Without appname configuration, this becomes very difficult in our environment.