### PR TITLE
Fixes broken select on find with populates

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -446,11 +446,6 @@ module.exports = (function() {
      */
     join: function (connectionName, collectionName, criteria, cb) {
 
-      // Ignore `select` from waterline core
-      if (typeof criteria === 'object') {
-        delete criteria.select;
-      }
-
       var connectionObject = connections[connectionName];
       var collection = connectionObject.collections[collectionName];
 


### PR DESCRIPTION
I know 0.12.x is not being "worked on", but just in case anyone else is having the same issue, I'm posting it here as a PR.

So, fixes situation where Pet will return all attributes, even though you only select 'name'. Just for reference: SELECT only works on sails-mongo in 0.12.x.

```javascript
Pet.find({select:['name']}).populate('owner').find().exec(console.log)
```

Related to 
 https://github.com/balderdashy/sails-mongo/pull/292