### PR TITLE
Added datastore property to registeredDryModels

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -343,6 +343,7 @@ module.exports = {
               attributes: phModelInfo.definition,
               tableName: phModelInfo.tableName,
               identity: phModelInfo.identity,
+              datastore: datastoreName,
             };
 
             // console.log('\n\nphModelInfo:',util.inspect(phModelInfo,{depth:5}));


### PR DESCRIPTION
Added datastore to registeredDryModels as teardown uses this property to remove models from the adapter, i.e.

        try {
          delete registeredDsEntries[datastoreName];

          _.each(_.keys(registeredDryModels), function(modelIdentity) {
            if (registeredDryModels[modelIdentity].datastore === datastoreName) {
              delete registeredDryModels[modelIdentity];
            }
          });

        } catch (e) { return done(e); }

In registerDatastore the property datastore is not added to registeredDryModels, i.e.

            if (registeredDryModels[phModelInfo.identity]) {
              throw new Error('Consistency violation: Cannot register model: `' + phModelInfo.identity + '`, because it is already registered with this adapter!  This could be due to an unexpected race condition in userland code (e.g. attempting to initialize multiple ORM instances at the same time), or it could be due to a bug in this adapter.  (If you get stumped, reach out at http://sailsjs.com/support.)');
            }

            registeredDryModels[phModelInfo.identity] = {
              primaryKey: phModelInfo.primaryKey,
              attributes: phModelInfo.definition,
              tableName: phModelInfo.tableName,
              identity: phModelInfo.identity,
            };
Which means that registeredDryModels[modelIdentity].datastore will always be undefined and not remove the model from registeredDryModels causing registerDatastore to throw "Consitency violation" error if you need to reinitialize waterline.