### PR TITLE
pushed mongodb native package to v3.0

### DIFF
--- a/lib/private/machines/avg-records.js
+++ b/lib/private/machines/avg-records.js
@@ -74,12 +74,15 @@ module.exports = {
           }
         }
       }
-    ], function aggregateCb(err, nativeResult) {
+    ], function aggregateCb(err, cursor) {
       if (err) { return exits.error(err); }
+      cursor.toArray(function(err, nativeResult) {
+        if (err) { return exits.error(err); }
 
-      var mean = 0;
-      if (_.first(nativeResult)) { mean = _.first(nativeResult).avg; }
-      return exits.success(mean);
+        var mean = 0;
+        if (_.first(nativeResult)) { mean = _.first(nativeResult).avg; }
+        return exits.success(mean);
+      });
     });//</ db.collection(...).aggregate() >
   }
 

--- a/lib/private/machines/create-manager.js
+++ b/lib/private/machines/create-manager.js
@@ -1,14 +1,10 @@
 module.exports = {
 
-
   friendlyName: 'Create manager',
-
 
   description: 'Build and initialize a connection manager instance (in Mongo, this is `db`).',
 
-
   moreInfoUrl: 'https://github.com/node-machine/driver-interface/blob/master/machines/create-manager.js',
-
 
   inputs: {
 
@@ -37,7 +33,6 @@ module.exports = {
 
   },
 
-
   exits: {
 
     success: {
@@ -65,20 +60,20 @@ module.exports = {
     failed: {
       description: 'Could not connect to Mongo using the specified connection URL.',
       extendedDescription:
-        'If this exit is called, it might mean any of the following:\n' +
-        ' + the credentials encoded in the connection string are incorrect\n' +
-        ' + there is no database server running at the provided host (i.e. even if it is just that the database process needs to be started)\n' +
-        ' + there is no software "database" with the specified name running on the server\n' +
-        ' + the provided connection string does not have necessary access rights for the specified software "database"\n' +
-        ' + this Node.js process could not connect to the database, perhaps because of firewall/proxy settings\n' +
-        ' + any other miscellaneous connection error\n' +
-        '\n' +
-        'Note that even if the database is unreachable, bad credentials are being used, etc, ' +
-        'this exit will not necessarily be called-- that depends on the implementation of the driver ' +
-        'and any special configuration passed to the `meta` input. e.g. if a pool is being used that spins up ' +
-        'multiple connections immediately when the manager is created, then this exit will be called if any of ' +
-        'those initial attempts fail. On the other hand, if the manager is designed to produce adhoc connections, ' +
-        'any errors related to bad credentials, connectivity, etc. will not be caught until `getConnection()` is called.',
+      'If this exit is called, it might mean any of the following:\n' +
+      ' + the credentials encoded in the connection string are incorrect\n' +
+      ' + there is no database server running at the provided host (i.e. even if it is just that the database process needs to be started)\n' +
+      ' + there is no software "database" with the specified name running on the server\n' +
+      ' + the provided connection string does not have necessary access rights for the specified software "database"\n' +
+      ' + this Node.js process could not connect to the database, perhaps because of firewall/proxy settings\n' +
+      ' + any other miscellaneous connection error\n' +
+      '\n' +
+      'Note that even if the database is unreachable, bad credentials are being used, etc, ' +
+      'this exit will not necessarily be called-- that depends on the implementation of the driver ' +
+      'and any special configuration passed to the `meta` input. e.g. if a pool is being used that spins up ' +
+      'multiple connections immediately when the manager is created, then this exit will be called if any of ' +
+      'those initial attempts fail. On the other hand, if the manager is designed to produce adhoc connections, ' +
+      'any errors related to bad credentials, connectivity, etc. will not be caught until `getConnection()` is called.',
       outputFriendlyName: 'Report',
       outputDescription: 'The `error` property is a JavaScript Error instance with more information and a stack trace. The `meta` property is reserved for custom driver-specific extensions.',
       outputExample: {
@@ -114,8 +109,10 @@ module.exports = {
       normalizeDatastoreConfig(_clientConfig, CONFIG_WHITELIST, EXPECTED_URL_PROTOCOL_PFX);
     } catch (e) {
       switch (e.code) {
-        case 'E_BAD_CONFIG': return exits.malformed({ error: e, meta: undefined });
-        default: return exits.error(e);
+        case 'E_BAD_CONFIG':
+          return exits.malformed({error: e, meta: undefined});
+        default:
+          return exits.error(e);
       }
     }
 
@@ -123,16 +120,16 @@ module.exports = {
     // (we don't need any of them now anyway, since we know at this point that
     // they'll have been baked into the URL)
     var mongoUrl = _clientConfig.url;
-    _clientConfig = _.omit(_clientConfig, ['url', 'user', 'password', 'host', 'port', 'database']);
+    var mongoClientConfig = _.omit(_clientConfig, ['url', 'user', 'password', 'host', 'port', 'database']);
 
-    NodeMongoDBNativeLib.MongoClient.connect(mongoUrl, _clientConfig, function connectCb(err, db) {
+    NodeMongoDBNativeLib.MongoClient.connect(mongoUrl, mongoClientConfig, function connectCb(err, client) {
       if (err) {
         return exits.error(err);
       }
 
       // `db` will be our manager.
       // (This variable is just for clarity.)
-      var manager = db;
+      var manager = client.db(_clientConfig.database);
 
       // Now mutate this manager, giving it a telltale.
       //
@@ -143,6 +140,7 @@ module.exports = {
       // > anyway.  No, the real reason is so that there's a way to tell if a given Mongo client
       // > instance came from mp-mongo or not, for debugging reasons.)
       manager._isFromMPMongo = true;
+      manager.client = client;
 
       return exits.success({
         manager: manager,
@@ -150,6 +148,5 @@ module.exports = {
       });
     });//</ .connect() >
   }
-
 
 };

--- a/lib/private/machines/destroy-manager.js
+++ b/lib/private/machines/destroy-manager.js
@@ -69,12 +69,12 @@ module.exports = {
     // If the manager doesn't have a `close` function for some reason,
     // then catch that ahead of time so we can provide a slightly nicer
     // error message and help prevent confusion.
-    if (!_.isObject(inputs.manager) || !_.isFunction(inputs.manager.close)) {
+    if (!_.isObject(inputs.manager) || !_.isFunction(inputs.manager.client.close)) {
       return exits.error(new Error('The provided `manager` is not a valid manager created by this driver.  (It should be a dictionary which contains a `close` function, at the very least.)'));
     }
 
     // Call close on the manager
-    inputs.manager.close();
+    inputs.manager.client.close();
 
     return exits.success({
       meta: inputs.meta

--- a/lib/private/machines/release-connection.js
+++ b/lib/private/machines/release-connection.js
@@ -67,7 +67,7 @@ module.exports = {
     // If the connection doesn't have a `close` function for some reason,
     // then catch that ahead of time so we can provide a slightly nicer
     // error message and help prevent confusion.
-    if (!_.isObject(inputs.connection) || !_.isFunction(inputs.connection.close)) {
+    if (!_.isObject(inputs.connection) || !_.isFunction(inputs.connection.client.close)) {
       return exits.badConnection();
     }
 

--- a/lib/private/machines/sum-records.js
+++ b/lib/private/machines/sum-records.js
@@ -74,12 +74,14 @@ module.exports = {
           }
         }
       }
-    ], function aggregateCb(err, nativeResult) {
+    ], function aggregateCb(err, cursor) {
       if (err) { return exits.error(err); }
-
-      var sum = 0;
-      if (_.first(nativeResult)) { sum = _.first(nativeResult).sum; }
-      return exits.success(sum);
+      cursor.toArray(function(err, nativeResult) {
+        if (err) { return exits.error(err); }
+        var sum = 0;
+        if (_.first(nativeResult)) { sum = _.first(nativeResult).sum; }
+        return exits.success(sum);
+      });
     });//</ db.collection(...).aggregate() >
   }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "async": "2.0.1",
     "flaverr": "1.1.1",
     "machine": "^13.0.0-17",
-    "mongodb": "2.2.25",
+    "mongodb": "3.0.1",
     "qs": "6.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
hey there, 

I updated the package to use mongodb native 3.0, so sails users can make use of the new mongodb 3.6 version. I choose to not completely rewrite everything so that it matches the new mongoclient logic, but instead attached the mongoclient object to the manager as the client attribute so it can be accessed.

for the changes introduced in mongodb native driver 3.0 see https://github.com/mongodb/node-mongodb-native/blob/3.0.0/CHANGES_3.0.0.md

Please review and merge if suitable