### PR TITLE
added meta option makeLikeModifierCaseInsensitiveInMongo

### DIFF
--- a/lib/private/machines/private/build-mongo-where-clause.js
+++ b/lib/private/machines/private/build-mongo-where-clause.js
@@ -212,6 +212,9 @@ module.exports = function buildMongoWhereClause(whereClause, WLModel, meta) {
 
       case 'like':
         constraint['$regex'] = new RegExp('^' + _.escapeRegExp(modifier).replace(/^%/, '.*').replace(/([^\\])%/g, '$1.*').replace(/\\%/g, '%') + '$');
+        if (_.isBoolean(meta.makeLikeModifierCaseInsensitiveInMongo) && meta.makeLikeModifierCaseInsensitiveInMongo) {
+          constraint['$options'] = 'i'
+        }
         break;
 
       default:


### PR DESCRIPTION
Option to make insensitive queries with like,
related suggest: https://github.com/balderdashy/sails-mongo/pull/464#issuecomment-333395049 and
related on trello: https://trello.com/c/GHUSXlV1/185-i-want-to-be-able-to-toggle-case-sensitivity-on-or-off-for-like-contains-startswith-endswith-modifiers-in-my-where-clause
reference: https://docs.mongodb.com/manual/reference/operator/query/regex/