### PR TITLE
added meta option makeLikeModifierCaseInsensitiveInMongo 

### DIFF
--- a/lib/private/machines/private/build-mongo-where-clause.js
+++ b/lib/private/machines/private/build-mongo-where-clause.js
@@ -212,7 +212,7 @@ module.exports = function buildMongoWhereClause(whereClause, WLModel, meta) {
 
       case 'like':
         constraint['$regex'] = new RegExp('^' + _.escapeRegExp(modifier).replace(/^%/, '.*').replace(/([^\\])%/g, '$1.*').replace(/\\%/g, '%') + '$');
-        if (_.isBoolean(meta.makeLikeModifierCaseInsensitiveInMongo) && meta.makeLikeModifierCaseInsensitiveInMongo) {
+        if (meta && meta.makeLikeModifierCaseInsensitiveInMongo && _.isBoolean(meta.makeLikeModifierCaseInsensitiveInMongo)) {
           constraint['$options'] = 'i';
         }
         break;

--- a/lib/private/machines/private/build-mongo-where-clause.js
+++ b/lib/private/machines/private/build-mongo-where-clause.js
@@ -213,7 +213,7 @@ module.exports = function buildMongoWhereClause(whereClause, WLModel, meta) {
       case 'like':
         constraint['$regex'] = new RegExp('^' + _.escapeRegExp(modifier).replace(/^%/, '.*').replace(/([^\\])%/g, '$1.*').replace(/\\%/g, '%') + '$');
         if (_.isBoolean(meta.makeLikeModifierCaseInsensitiveInMongo) && meta.makeLikeModifierCaseInsensitiveInMongo) {
-          constraint['$options'] = 'i'
+          constraint['$options'] = 'i';
         }
         break;
 

--- a/lib/private/machines/private/build-mongo-where-clause.js
+++ b/lib/private/machines/private/build-mongo-where-clause.js
@@ -212,6 +212,9 @@ module.exports = function buildMongoWhereClause(whereClause, WLModel, meta) {
 
       case 'like':
         constraint['$regex'] = new RegExp('^' + _.escapeRegExp(modifier).replace(/^%/, '.*').replace(/([^\\])%/g, '$1.*').replace(/\\%/g, '%') + '$');
+        if (_.isBoolean(meta.makeLikeModifierCaseInsensitiveInMongo) && meta.makeLikeModifierCaseInsensitiveInMongo) {
+          constraint['$options'] = 'i'
+        }
         break;
 
       default:

--- a/lib/private/machines/private/build-mongo-where-clause.js
+++ b/lib/private/machines/private/build-mongo-where-clause.js
@@ -212,7 +212,7 @@ module.exports = function buildMongoWhereClause(whereClause, WLModel, meta) {
 
       case 'like':
         constraint['$regex'] = new RegExp('^' + _.escapeRegExp(modifier).replace(/^%/, '.*').replace(/([^\\])%/g, '$1.*').replace(/\\%/g, '%') + '$');
-        if (meta && meta.makeLikeModifierCaseInsensitiveInMongoAndSailsDisk && _.isBoolean(meta.makeLikeModifierCaseInsensitiveInMongoAndSailsDisk)) {
+        if (meta && meta.makeLikeModifierCaseInsensitive && _.isBoolean(meta.makeLikeModifierCaseInsensitive)) {
           constraint['$options'] = 'i';
         }
         break;

--- a/lib/private/machines/private/build-mongo-where-clause.js
+++ b/lib/private/machines/private/build-mongo-where-clause.js
@@ -212,7 +212,7 @@ module.exports = function buildMongoWhereClause(whereClause, WLModel, meta) {
 
       case 'like':
         constraint['$regex'] = new RegExp('^' + _.escapeRegExp(modifier).replace(/^%/, '.*').replace(/([^\\])%/g, '$1.*').replace(/\\%/g, '%') + '$');
-        if (meta && meta.makeLikeModifierCaseInsensitiveInMongo && _.isBoolean(meta.makeLikeModifierCaseInsensitiveInMongo)) {
+        if (meta && meta.makeLikeModifierCaseInsensitiveInMongoAndSailsDisk && _.isBoolean(meta.makeLikeModifierCaseInsensitiveInMongoAndSailsDisk)) {
           constraint['$options'] = 'i';
         }
         break;


### PR DESCRIPTION
Option to make insensitive queries with like,
related suggest: #464 (comment) and
related on trello: https://trello.com/c/GHUSXlV1/185-i-want-to-be-able-to-toggle-case-sensitivity-on-or-off-for-like-contains-startswith-endswith-modifiers-in-my-where-clause
reference: https://docs.mongodb.com/manual/reference/operator/query/regex/