### PR TITLE
upgrade mongodb driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.12.4
 
-* [INTERNAL] Bump `mongodb` version to support MongoDB 3.6
+* [INTERNAL] Bump `mongodb` version to support MongoDB 3.6 and update connection options
 * [INTERNAL] Cleanup `.find()` and `.destroy()`.
 
 ### 0.12.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.12.4
 
-* [INTERNAL] Bump `mongodb` version for
+* [INTERNAL] Bump `mongodb` version to support MongoDB 3.6
 * [INTERNAL] Cleanup `.find()` and `.destroy()`.
 
 ### 0.12.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Sails-Mongo Changelog
 
+
 ### 0.12.4
 
 * [INTERNAL] Bump `mongodb` version to support MongoDB 3.6 and update connection options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Sails-Mongo Changelog
 
-
 ### 0.12.4
 
 * [INTERNAL] Bump `mongodb` version to support MongoDB 3.6 and update connection options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Sails-Mongo Changelog
 
+### 0.12.4
+
+* [INTERNAL] Bump `mongodb` version for
+* [INTERNAL] Cleanup `.find()` and `.destroy()`.
+
 ### 0.12.2
 
 * [INTERNAL] Bump and pin dependency versions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@
 # https://www.appveyor.com/docs/lang/nodejs-iojs/ #
 # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-
 # Test against these versions of Node.js.
 environment:
   matrix:
@@ -19,6 +18,10 @@ environment:
     - nodejs_version: "5"
     - nodejs_version: "6"
     - nodejs_version: "7"
+    - nodejs_version: "8"
+    - nodejs_version: "9"
+
+image: ubuntu
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ install:
   # Get the latest stable version of Node.js
   # (Not sure what this is for, it's just in Appveyor's example.)
   - ps: Install-Product node $env:nodejs_version
+  - choco install make
   # Install declared dependencies
   - npm install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,6 @@ install:
   # Install declared dependencies
   - npm install
 
-
 #  Test scripts.
 test_script:
   # Output Node and NPM version info.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ environment:
     - nodejs_version: "7"
     - nodejs_version: "8"
     - nodejs_version: "9"
+    - nodejs_version: "10"
 
 # Install and run MongoDB
 services:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,3 +55,6 @@ build: off
 # https://www.appveyor.com/docs/services-databases/
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+services:
+  - mongodb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,17 +21,20 @@ environment:
     - nodejs_version: "8"
     - nodejs_version: "9"
 
-# Install scripts. (runs after repo cloning)
+# Install and run MongoDB
+services:
+  - mongodb
+
+# Install scripts.
 install:
   # Get the latest stable version of Node.js
-  # (Not sure what this is for, it's just in Appveyor's example.)
   - ps: Install-Product node $env:nodejs_version
   - choco install make
   # Install declared dependencies
   - npm install
 
 
-# Post-install test scripts.
+#  Test scripts.
 test_script:
   # Output Node and NPM version info.
   # (Presumably just in case Appveyor decides to try any funny business?
@@ -41,20 +44,4 @@ test_script:
   # Run the actual tests.
   - npm test
 
-
-# Don't actually build.
-# (Not sure what this is for, it's just in Appveyor's example.
-#  I'm not sure what we're not building... but I'm OK with not
-#  building it.  I guess.)
 build: off
-
-
-# # # # # # # # # # # # # # # # # # # # # # # # # # # #
-
-# TODO: Set up appveyor + mongo*:
-# https://www.appveyor.com/docs/services-databases/
-
-# # # # # # # # # # # # # # # # # # # # # # # # # # # #
-
-services:
-  - mongodb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.10"
     - nodejs_version: "0.12"
     - nodejs_version: "4"
     - nodejs_version: "5"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,6 @@ environment:
     - nodejs_version: "8"
     - nodejs_version: "9"
 
-image: ubuntu
-
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -47,26 +47,18 @@ module.exports = (function() {
       // DB Options
       w: 1,
       wtimeout: 0,
-      fsync: false,
-      journal: false,
       readPreference: null,
       nativeParser: false,
       forceServerObjectId: false,
-      recordQueryStats: false,
-      retryMiliSeconds: 5000,
-      numberOfRetries: 5,
 
       // Server Options
       ssl: false,
       poolSize: 5,
-      socketOptions: {
-        noDelay: true,
-        keepAlive: 0,
-        connectTimeoutMS: 0,
-        socketTimeoutMS: 0
-      },
+      noDelay: true,
+      keepAlive: 0,
+      connectTimeoutMS: 0,
+      socketTimeoutMS: 0,
       auto_reconnect: true,
-      disableDriverBSONSizeCheck: false,
       reconnectTries: 30, // defaults to mongodb recommended settings
       reconnectInterval: 1000, // defaults to mongodb recommended settings
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -79,6 +79,7 @@ Collection.prototype.find = function find(criteria, cb) {
     ];
 
     return collection.aggregate(aggregate, function(err, results) {
+      if(err) return cb(err);
 
       // Results have grouped by values under _id, so we extract them
       var mapped = results.map(function(result) {
@@ -89,7 +90,7 @@ Collection.prototype.find = function find(criteria, cb) {
         return result;
       });
 
-      cb(err, mapped);
+      cb(null, mapped);
     });
   }
 
@@ -290,7 +291,7 @@ Collection.prototype.destroy = function destroy(criteria, cb) {
       resultsArray.push({ id: result });
     });
 
-    cb(null, utils.rewriteIds(resultArray, self.schema));
+    cb(null, utils.rewriteIds(resultsArray, self.schema));
   });
 };
 

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -78,7 +78,7 @@ Collection.prototype.find = function find(criteria, cb) {
       { '$group': query.aggregateGroup }
     ];
 
-    return collection.aggregate(aggregate, function(err, results) {
+    return collection.aggregate(aggregate, { cursor: {} }).toArray(function(err, results) {
       if(err) return cb(err);
 
       // Results have grouped by values under _id, so we extract them

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -85,7 +85,7 @@ Connection.prototype.dropCollection = function dropCollection(name, cb) {
  * @api private
  */
 
-var ignoredConnectionOptions =  ['host', 'database', 'port', 'nativeParser', 'safe', 'identity', 'user', 'password', 'schema', 'url', 'auto_reconnect', 'wlNext', 'adapter', 'version'];
+var ignoredConnectionOptions =  ['host', 'database', 'port', 'nativeParser', 'safe', 'identity', 'user', 'password', 'ssl', 'schema', 'url', 'auto_reconnect', 'wlNext', 'adapter', 'version'];
 
 Connection.prototype._buildConnection = function _buildConnection(cb) {
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -85,46 +85,18 @@ Connection.prototype.dropCollection = function dropCollection(name, cb) {
  * @api private
  */
 
+var ignoredConnectionOptions =  ['host', 'database', 'port', 'nativeParser', 'safe', 'identity', 'user', 'password', 'schema', 'url', 'auto_reconnect', 'wlNext', 'adapter', 'version'];
+
 Connection.prototype._buildConnection = function _buildConnection(cb) {
 
   // Set the configured options
   var connectionOptions = {};
-  
-  connectionOptions.mongos = this.config.mongos || {};
-  connectionOptions.replSet = this.config.replSet || {};
 
-  // Build up options used for creating a Server instance
-  connectionOptions.server = {
-    readPreference: this.config.readPreference,
-    ssl: this.config.ssl,
-    sslValidate: this.config.sslValidate,
-    sslCA: this.config.sslCA,
-    sslCert: this.config.sslCert,
-    sslKey: this.config.sslKey,
-    poolSize: this.config.poolSize,
-    socketOptions: this.config.socketOptions,
-    autoReconnect: this.config.auto_reconnect,
-    disableDriverBSONSizeCheck: this.config.disableDriverBSONSizeCheck,
-    reconnectInterval: this.config.reconnectInterval,
-    reconnectTries: this.config.reconnectTries
-  };
-
-  // Build up options used for creating a Database instance
-  connectionOptions.db = {
-    w: this.config.w,
-    wtimeout: this.config.wtimeout,
-    fsync: this.config.fsync,
-    journal: this.config.journal,
-    readPreference: this.config.readPreference,
-    native_parser: this.config.nativeParser,
-    forceServerObjectId: this.config.forceServerObjectId,
-    recordQueryStats: this.config.recordQueryStats,
-    retryMiliSeconds: this.config.retryMiliSeconds,
-    numberOfRetries: this.config.numberOfRetries
-  };
-
-  // Support for encoded auth credentials
-  connectionOptions.uri_decode_auth = this.config.uri_decode_auth || false;
+  Object.keys(this.config).filter(function (option) {
+    return ignoredConnectionOptions.indexOf(option) === -1;
+  }).forEach(function (option) {
+    connectionOptions[option] = this.config[option];
+  }.bind(this))
 
   // Build A Mongo Connection String
   var connectionString = 'mongodb://';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-mongo",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Mongo DB adapter for Sails.js",
   "main": "./lib/adapter.js",
   "scripts": {
@@ -45,7 +45,7 @@
   "dependencies": {
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
-    "mongodb": "2.2.22",
+    "mongodb": "^2.2.22",
     "validator": "4.5.1",
     "waterline-cursor": "0.0.7",
     "waterline-errors": "0.10.1"


### PR DESCRIPTION
- upgrade mongodb driver to `^2.2.22` (to support MongoDB 3.6) and update connection options
- cleanup/fix `find()` and `destroy()`
- drops support for Node.js 0.10 since [it breaks tests](https://ci.appveyor.com/project/mikermcneil/sails-mongo/build/1.0.171/job/3k7550l81nke0u2t)
- add Node.js 8, 9 and 10 to CI