### PR TITLE
Fix issue with aggregation with MongoDB version >=3.4. Now the cursor option is mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@
 language: node_js
 
 node_js:
-  - "4"
   - "6"
   - "8"
   - "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,34 @@ node_js:
   - "4"
   - "6"
   - "8"
-  - "node"
+  - "9"
 
 env:
   - WATERLINE_ADAPTER_TESTS_URL=root@localhost/testdb
+  matrix:
+  - MONGODB=3.4.16
+  - MONGODB=3.6.6
+  - MONGODB=4.0.0
+  - MONGODB=4.1.1
+
+matrix:
+  fast_finish: true
+
+install:
+- wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz
+- tar xzf mongodb-linux-x86_64-${MONGODB}.tgz
+- ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --version
+- npm install
+
+before_script:
+- mkdir ${PWD}/mongodb-linux-x86_64-${MONGODB}/data
+- ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath ${PWD}/mongodb-linux-x86_64-${MONGODB}/data --logpath ${PWD}/mongodb-linux-x86_64-${MONGODB}/mongodb.log --fork
+
+script:
+- npm test
+
+after_script:
+- pkill mongod
 
 branches:
   only:
@@ -27,6 +51,3 @@ branches:
 notifications:
   email:
     - ci@sailsjs.com
-
-services:
-  - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
   - MONGODB=3.4.16
   - MONGODB=3.6.6
   - MONGODB=4.0.0
-  - MONGODB=4.1.1
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ node_js:
   - "4"
   - "6"
   - "8"
-  - "9"
+  - "10"
 
 env:
   - WATERLINE_ADAPTER_TESTS_URL=root@localhost/testdb

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ after_script:
 branches:
   only:
     - master
+    - fix-aggregate-mongodb34
 
 notifications:
   email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # sails-mongo Changelog
 
+### In development
+
+* [BUG] Fix issue with aggregation with MongoDB version >=3.4. Now the cursor option is mandatory. [@luislobo](https://github.com/luislobo)
+
 ### 1.0.0
 
 * [COMPATIBILITY] Upgrade to v1 of the Waterline adapter API.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@
 environment:
   WATERLINE_ADAPTER_TESTS_URL: root@localhost/testdb
   matrix:
-    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "10"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,10 @@ install:
   # Install declared dependencies
   - npm install
 
+branches:
+  only:
+  - master
+  - fix-aggregate-mongodb34
 
 # Post-install test scripts.
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@
 
 # Test against these versions of Node.js.
 environment:
+  - WATERLINE_ADAPTER_TESTS_URL=root@localhost/testdb
   matrix:
     - nodejs_version: "4"
     - nodejs_version: "6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@
 
 # Test against these versions of Node.js.
 environment:
-  - WATERLINE_ADAPTER_TESTS_URL=root@localhost/testdb
+  - WATERLINE_ADAPTER_TESTS_URL: root@localhost/testdb
   matrix:
     - nodejs_version: "4"
     - nodejs_version: "6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@
 
 # Test against these versions of Node.js.
 environment:
-  - WATERLINE_ADAPTER_TESTS_URL: root@localhost/testdb
+  WATERLINE_ADAPTER_TESTS_URL: root@localhost/testdb
   matrix:
     - nodejs_version: "4"
     - nodejs_version: "6"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,4 @@ adapter:
    - NODE_ENV=test
 
 mongo:
-  image: mongo
+  image: mongo:4

--- a/lib/private/machines/avg-records.js
+++ b/lib/private/machines/avg-records.js
@@ -64,7 +64,7 @@ module.exports = {
     //  ╚═╝╚═╝╩ ╩╩ ╩╚═╝╝╚╝╩╚═╝╩ ╩ ╩ ╚═╝  └┴┘┴ ┴ ┴ ┴  ─┴┘└─┘
     var db = inputs.connection;
     var mongoCollection = db.collection(tableName);
-    mongoCollection.aggregate([
+    var cursor = mongoCollection.aggregate([
       { $match: mongoWhere },
       {
         $group: {
@@ -74,7 +74,9 @@ module.exports = {
           }
         }
       }
-    ], function aggregateCb(err, nativeResult) {
+    ], { cursor: {} });
+
+    cursor.toArray(function aggregateCb(err, nativeResult) {
       if (err) { return exits.error(err); }
 
       var mean = 0;

--- a/lib/private/machines/sum-records.js
+++ b/lib/private/machines/sum-records.js
@@ -64,7 +64,7 @@ module.exports = {
     //  ╚═╝╚═╝╩ ╩╩ ╩╚═╝╝╚╝╩╚═╝╩ ╩ ╩ ╚═╝  └┴┘┴ ┴ ┴ ┴  ─┴┘└─┘
     var db = inputs.connection;
     var mongoCollection = db.collection(tableName);
-    mongoCollection.aggregate([
+    var cursor = mongoCollection.aggregate([
       { $match: mongoWhere },
       {
         $group: {
@@ -74,7 +74,9 @@ module.exports = {
           }
         }
       }
-    ], function aggregateCb(err, nativeResult) {
+    ], { cursor: {} });
+
+    cursor.toArray(function aggregateCb(err, nativeResult) {
       if (err) { return exits.error(err); }
 
       var sum = 0;


### PR DESCRIPTION
Fix issue with aggregation with MongoDB version >=3.4. Now the cursor option is mandatory