### PR TITLE
[patch] Backport of memleak fix to 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-mongo",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Mongo DB adapter for Sails.js",
   "main": "./lib/adapter.js",
   "scripts": {


### PR DESCRIPTION
Backport of https://github.com/balderdashy/sails-mongo/pull/481 to the 0.12.x line.