### PR TITLE
[fixes #6979] Fix input not normalising to ObjectId for certain query operators

### DIFF
--- a/lib/private/machines/private/build-mongo-where-clause.js
+++ b/lib/private/machines/private/build-mongo-where-clause.js
@@ -6,6 +6,7 @@ var util = require('util');
 var assert = require('assert');
 var _ = require('@sailshq/lodash');
 var normalizeMongoObjectId = require('./normalize-mongo-object-id');
+var tryNormalizeMongoObjectId = require('./try-normalize-mongo-object-id');
 
 
 /**
@@ -131,19 +132,31 @@ module.exports = function buildMongoWhereClause(whereClause, WLModel, meta) {
     switch (modifierKind) {
 
       case '<':
-        constraint['$lt'] = modifier;
+        // Apply our modifier as an ObjectId where appropriate.
+        constraint['$lt'] = (doCompareAsObjectIdIfPossible && _.isString(modifier))
+          ? tryNormalizeMongoObjectId(modifier)
+          : modifier;
         break;
 
       case '<=':
-        constraint['$lte'] = modifier;
+        // Apply our modifier as an ObjectId where appropriate.
+        constraint['$lte'] = (doCompareAsObjectIdIfPossible && _.isString(modifier))
+          ? tryNormalizeMongoObjectId(modifier)
+          : modifier;
         break;
 
       case '>':
-        constraint['$gt'] = modifier;
+        // Apply our modifier as an ObjectId where appropriate.
+        constraint['$gt'] = (doCompareAsObjectIdIfPossible && _.isString(modifier))
+          ? tryNormalizeMongoObjectId(modifier)
+          : modifier;
         break;
 
       case '>=':
-        constraint['$gte'] = modifier;
+        // Apply our modifier as an ObjectId where appropriate.
+        constraint['$gte'] = (doCompareAsObjectIdIfPossible && _.isString(modifier))
+          ? tryNormalizeMongoObjectId(modifier)
+          : modifier;
         break;
 
       case '!=':

--- a/lib/private/machines/private/try-normalize-mongo-object-id.js
+++ b/lib/private/machines/private/try-normalize-mongo-object-id.js
@@ -1,0 +1,32 @@
+/**
+ * Module dependencies
+ */
+
+var normalizeMongoObjectId = require('./normalize-mongo-object-id');
+
+/**
+ * tryNormalizeMongoObjectId()
+ *
+ * Attempts to convert the given value to a Mongo ObjectId and return it. If the value
+ * simply cannot be interpreted as an ObjectId, it will be returned as-is.
+ *
+ * This function is equivalent to calling the `normalizeMongoObjectId()` function with
+ * tolerance for the `E_CANNOT_INTERPRET_AS_OBJECTID` error whereby the input value is
+ * yielded instead in such cases, allowing one to avoid inlining try-catch blocks.
+ *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * @param value - Value to attempt normalization of.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * @returns Returns the given value normalized to an `ObjectId` if possible. Otherwise
+ * returns the original value.
+ */
+module.exports = function tryNormalizeMongoObjectId(value) {
+  try {
+    return normalizeMongoObjectId(value);
+  } catch (e) {
+    switch (e.code) {
+      case 'E_CANNOT_INTERPRET_AS_OBJECTID': return value;
+      default: throw e;
+    }
+  }
+};


### PR DESCRIPTION
This PR fixes https://github.com/balderdashy/sails/issues/6979.

All tests appear to be passing locally. Further, these changes don't appear to have caused any problems with our large app/test suites.

I'd like to have tests added to validate this behaviour and prevent any sort of regression; would [balderdashy/waterline-adapter-tests](https://github.com/balderdashy/waterline-adapter-tests) be the correct place to have this done, or should we create only adapter-specific tests here?