### PR TITLE
[patch] Several improvements to the test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,44 +9,58 @@
 # https://docs.travis-ci.com/user/customizing-the-build #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+dist: xenial
+
 language: node_js
 
 node_js:
-  - "6"
-  - "8"
   - "10"
+  - "12"
+  - "14"
 
 env:
-  - WATERLINE_ADAPTER_TESTS_URL=root@localhost/testdb
+  global:
+    - WATERLINE_ADAPTER_TESTS_URL=localhost/testdb
+    - WATERLINE_ADAPTER_TESTS_HOST=localhost
+    - WATERLINE_ADAPTER_TESTS_DATABASE=sails-mongo
+    - NODE_ENV=test
+
   matrix:
-  - MONGODB=3.4.16
-  - MONGODB=3.6.6
-  - MONGODB=4.0.0
+    - MONGODB=3.6.18
+    - MONGODB=4.0.18
+    - MONGODB=4.2.7
+
+cache:
+  directories:
+#    - "$TRAVIS_BUILD_DIR/mongodb/mongodb-linux-x86_64-${MONGODB}"
+    - "$HOME/.npm"
 
 matrix:
   fast_finish: true
 
+before_install:
+  - chmod +x "$TRAVIS_BUILD_DIR/scripts/travis/install_mongodb.sh" "$TRAVIS_BUILD_DIR/scripts/travis/run_mongodb.sh"
+
 install:
-- wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz
-- tar xzf mongodb-linux-x86_64-${MONGODB}.tgz
-- ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --version
-- npm install
+  - npm i --no-audit
+  - "$TRAVIS_BUILD_DIR/scripts/travis/install_mongodb.sh"
 
 before_script:
-- mkdir ${PWD}/mongodb-linux-x86_64-${MONGODB}/data
-- ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath ${PWD}/mongodb-linux-x86_64-${MONGODB}/data --logpath ${PWD}/mongodb-linux-x86_64-${MONGODB}/mongodb.log --fork
+  - "$TRAVIS_BUILD_DIR/scripts/travis/run_mongodb.sh"
 
 script:
-- npm test
+  - npm test
 
 after_script:
-- pkill mongod
+  - pkill mongod
 
 branches:
   only:
     - master
-    - fix-aggregate-mongodb34
+    - upgrade-mongodb-drivers
+    - update-test-environment
 
 notifications:
   email:
     - ci@sailsjs.com
+    - luislobo@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 
 cache:
   directories:
-#    - "$TRAVIS_BUILD_DIR/mongodb/mongodb-linux-x86_64-${MONGODB}"
+    - "$TRAVIS_BUILD_DIR/mongodb"
     - "$HOME/.npm"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ before_install:
   - chmod +x "$TRAVIS_BUILD_DIR/scripts/travis/install_mongodb.sh" "$TRAVIS_BUILD_DIR/scripts/travis/run_mongodb.sh"
 
 install:
+  # Don't let npm send metrics as it creates a file in the .npm folder invalidating the cache every time
+  - npm config set send-metrics false
   - npm i --no-audit
   - "$TRAVIS_BUILD_DIR/scripts/travis/install_mongodb.sh"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,21 @@
 
 ### In development
 
-* [BUG] Fix issue with aggregation with MongoDB version >=3.4. Now the cursor option is mandatory. [@luislobo](https://github.com/luislobo)
+### 1.2.1
 
+* [ENHANCEMENT] Adds `npm run start-mongodb` and `npm run stop-mongodb` scripts to start/stop a MongoDB docker instance [@luislobo](@luislobo)
+* [ENHANCEMENT] Adds `npm run mongodb-shell` to run a MongoDB Shell CLI that connects to the MongoDB docker instance [@luislobo](@luislobo)
+* [INTERNAL] Bump and pin dependency versions [@luislobo](@luislobo)
+* [INTERNAL] Tests in Travis run against a combination of Node.js 10, 12, 14 and MongoDB: 3.6, 4.0, 4.2 [@luislobo](@luislobo)
+* [INTERNAL] Refactors docker-compose.yml, removing the need of Dockerfile. Updates Docker node version to 12, and MongoDB to 4.2 [@luislobo](@luislobo)
 
 ### 1.2.0
 
-* [ENHANCEMENT] Add support for `makeLikeModifierCaseInsensitive` meta key.  See [#470](https://github.com/balderdashy/sails-mongo/pull/470) for more details. Thanks [@anterodev](https://github.com/anterodev)!
+* [ENHANCEMENT] Add support for `makeLikeModifierCaseInsensitive` meta key.  See [#470](https://github.com/balderdashy/sails-mongo/pull/470) for more details. Thanks [@anterodev](@anterodev)!
+
+### 1.1.0
+
+* [BUG] Fix issue with aggregation with MongoDB version >=3.4. Now the cursor option is mandatory. [@luislobo](@luislobo)
 
 ### 1.0.0
 
@@ -20,20 +29,29 @@
 
 ### 0.12.1
 
-* [ENHANCEMENT] Sets the `reconnectInterval` to the mongo default and adds a `reconnectTries` configuration option. See [#118](https://github.com/balderdashy/sails-mongo/issues/118) for more details. Thanks [@luislobo](https://github.com/luislobo) for the patch!
+* [ENHANCEMENT] Sets the `reconnectInterval` to the mongo default and adds a `reconnectTries` configuration option. See [#118](https://github.com/balderdashy/sails-mongo/issues/118) for more details. Thanks [@luislobo](@luislobo) for the patch!
 
 ### 0.12.0
 
-* [ENHANCEMENT] Now exposes a flag `wlNext` that allows you to toggle the case sensitivity of a string query. See [#380](https://github.com/balderdashy/sails-mongo/pull/380) and [#238](https://github.com/balderdashy/sails-mongo/pull/238) for more. Thanks [@nicoespeon](https://github.com/nicoespeon).
+* [ENHANCEMENT] Now exposes a flag `wlNext` that allows you to toggle the case sensitivity of a string query. See [#380](https://github.com/balderdashy/sails-mongo/pull/380) and [#238](https://github.com/balderdashy/sails-mongo/pull/238) for more. Thanks [@nicoespeon](@nicoespeon).
 
 ### 0.11.7
 
-* [ENHANCEMENT] When running an update only return `_id` values when doing the initial lookup. See [#237](https://github.com/balderdashy/sails-mongo/pull/237) for more. Thanks [@andyhu](https://github.com/andyhu).
+* [ENHANCEMENT] When running an update only return `_id` values when doing the initial lookup. See [#237](https://github.com/balderdashy/sails-mongo/pull/237) for more. Thanks [@andyhu](@andyhu).
 
-* [ENHANCEMENT] Better error message for duplicate keys when using Wired Tiger. See [#372](https://github.com/balderdashy/sails-mongo/pull/372) for more. Thanks [@Mordred](https://github.com/Mordred).
+* [ENHANCEMENT] Better error message for duplicate keys when using Wired Tiger. See [#372](https://github.com/balderdashy/sails-mongo/pull/372) for more. Thanks [@Mordred](@Mordred).
 
-* [ENHANCEMENT] Allow multi-line queries when using `contains`, `like`, `startsWith`, and `endsWith`. See [#308](https://github.com/balderdashy/sails-mongo/pull/308) for more. Thanks [@vbud](https://github.com/vbud).
+* [ENHANCEMENT] Allow multi-line queries when using `contains`, `like`, `startsWith`, and `endsWith`. See [#308](https://github.com/balderdashy/sails-mongo/pull/308) for more. Thanks [@vbud](@vbud).
 
-* [BUG] Fix issue when returning results with the key `_id` that are not actual ObjectId instances. See [#356](https://github.com/balderdashy/sails-mongo/pull/356) for more. Thanks [@miccar](https://github.com/miccarr).
+* [BUG] Fix issue when returning results with the key `_id` that are not actual ObjectId instances. See [#356](https://github.com/balderdashy/sails-mongo/pull/356) for more. Thanks [@miccar](@miccar).
 
 * [STABILITY] Locked the dependency versions down.
+
+---
+[@anterodev]: https://github.com/anterodev
+[@luislobo]: https://github.com/luislobo
+[@nicoespeon]: https://github.com/nicoespeon
+[@andyhu]: https://github.com/andyhu
+[@Mordred]: https://github.com/Mordred
+[@vbud]: https://github.com/vbud
+[@miccar]: https://github.com/miccarr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # sails-mongo Changelog
 
-### In development
-
 ### 1.2.1
 
 * [ENHANCEMENT] Adds `npm run start-mongodb` and `npm run stop-mongodb` scripts to start/stop a MongoDB docker instance [@luislobo](@luislobo)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM nodesource/node:4.2
-
-ADD package.json package.json
-RUN npm install
-ADD . .
-
-CMD ["npm","test"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Visit [Models & ORM](http://sailsjs.com/docs/concepts/models-and-orm) in the doc
 
 ## Compatibility
 
-> This version of the adapter has been tested with MongoDB versions 3.4 and 3.6.
+> This version of the adapter has been tested with MongoDB versions 3.6, 4.0, and 4.2.
 
 This adapter implements the following methods:
 
@@ -63,14 +63,42 @@ Please observe the guidelines and conventions laid out in the [Sails project con
 [![NPM](https://nodei.co/npm/sails-mongo.png?downloads=true)](http://npmjs.com/package/sails-mongo)
 
 
+#### Development and Test
+
 This repository includes a Docker Compose file that helps setting up the environment needed to run the test.
 
-The `npm run docker-test` command runs the tests on a single run under the supported MongoDB version 
-(at this time, up to 3.6).
+The `npm test` command expects a local MongoDB instance running.
+
+For convenience, some new npm scripts are available:
+- `npm run start-mongodb`: Starts MongoDB docker instance
+- `npm run stop-mongodb`: Stops MongoDB docker instance
+- `npm run mongodb-shell`: Runs the MongoDB shell CLI, connects to the instance started by the `npm run start-mongodb` command.
+
+This simplifies development as you do not need to have a MongoDB instance running on the development computer.
+
+Notice that if you do have a local MongoDB instance, then, there might be port conflicts if you run the docker version.
+The docker version is configured to run on the standard port 27017.
+
+The normal development workflow would now be:
+- When starting a development session, `npm run start-mongdb`
+- Now we can execute `npm test` as many times as needed
+- When finishing a development session, `npm run stop-mongdb`
+
+The `npm run docker-test` command runs the tests on a single run under the latest MongoDB version (at the time 4.2).
+It automatically starts a MongoDB docker instance, and it stops it. This is useful for one time local tests.
+Note that since this command stops MongoDB, `npm test` will fail.
+
+When running automation tests in Travis, the module is tested under a combination of Node.js 10, 12, 14 and
+MongoDB: 3.6, 4.0, 4.2.
+
+When running automation tests in AppVeyor, the module is tested under a combination of Node.js 10, 12, 14 and
+the MongoDB version that AppVeyor supports. Multiple MongoDB version are not tested in AppVeyor.
+
 For more information, check [MongoDB's Support Policy](https://www.mongodb.com/support-policy).
 
 To run tests while developing, you can run `npm run docker`. This command opens a docker instance and opens a shell.
-From there you can run `npm test` to run the tests as many times as you need. 
+From there you can run `npm test` to run the tests as many times as you need.
+
 
 #### Special thanks
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,8 @@ install:
   # Get the latest stable version of Node.js
   # (Not sure what this is for, it's just in Appveyor's example.)
   - ps: Install-Product node $env:nodejs_version
+  # Don't let npm send metrics as it creates a file in the .npm folder invalidating the cache every time
+  - npm config set send-metrics false
   # Install declared dependencies
   - npm install --no-audit
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,14 @@
 
 # Test against these versions of Node.js.
 environment:
-  WATERLINE_ADAPTER_TESTS_URL: root@localhost/testdb
+  WATERLINE_ADAPTER_TESTS_URL: localhost/testdb
+  WATERLINE_ADAPTER_TESTS_HOST: localhost
+  WATERLINE_ADAPTER_TESTS_DATABASE: sails-mongo
+  NODE_ENV: test
   matrix:
-    - nodejs_version: "6"
-    - nodejs_version: "8"
     - nodejs_version: "10"
+    - nodejs_version: "12"
+    - nodejs_version: "14"
 
 # Install scripts. (runs after repo cloning)
 install:
@@ -24,12 +27,13 @@ install:
   # (Not sure what this is for, it's just in Appveyor's example.)
   - ps: Install-Product node $env:nodejs_version
   # Install declared dependencies
-  - npm install
+  - npm install --no-audit
 
 branches:
   only:
   - master
-  - fix-aggregate-mongodb34
+  - upgrade-mongodb-drivers
+  - update-test-environment
 
 # Post-install test scripts.
 test_script:
@@ -39,7 +43,7 @@ test_script:
   - node --version
   - npm --version
   # Run the actual tests.
-  - npm run custom-tests
+  - npm test
 
 # Setup Mongo Database
 services:
@@ -57,5 +61,5 @@ build: off
 
 # TODO: Set up appveyor + mongo*:
 # https://www.appveyor.com/docs/services-databases/
-
+# Old example on how to install different versions of MongoDB added to `scripts/appveyor/install_mongodb.ps1`
 # # # # # # # # # # # # # # # # # # # # # # # # # # # #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,22 @@
 adapter:
-  build: .
+  image: node:12
   volumes:
-   - .:/usr/src/app
+    - $PWD:/home/node/sails-mongo
   links:
-   - mongo
+    - mongo
   environment:
-   - WATERLINE_ADAPTER_TESTS_DATABASE=sails-mongo
-   - NODE_ENV=test
+    - WATERLINE_ADAPTER_TESTS_DATABASE=sails-mongo
+    - WATERLINE_ADAPTER_TESTS_URL=mongo/testdb
+    - WATERLINE_ADAPTER_TESTS_HOST=mongo
+    - NODE_ENV=test
+  user: node
+  working_dir: /home/node/sails-mongo
+  command:
+    - bash -c "npm test"
 
 mongo:
-  image: mongo:4
+  image: mongo:4.2
+  restart: always
+  command: "--logpath=/dev/null"
+  ports:
+    - "27017:27017"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
   "name": "sails-mongo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Mongo DB adapter for Sails.js/Waterline.",
   "main": "./lib",
   "scripts": {
     "test": "npm run lint && npm run custom-tests",
-    "custom-tests": "mocha test/run-adapter-specific-tests && mocha test/connectable/ && node test/run-standard-tests",
-    "lint": "eslint . --max-warnings=0",
+    "custom-tests": "node node_modules/mocha/bin/mocha test/run-adapter-specific-tests && node node_modules/mocha/bin/mocha test/connectable/ && node node_modules/mocha/bin/mocha test/run-standard-tests",
+    "lint": "node node_modules/eslint/bin/eslint . --max-warnings=0",
+    "start-mongodb": "docker-compose up -d mongo",
+    "stop-mongodb": "docker-compose down",
     "docker": "docker-compose run adapter bash",
-    "docker-test": "docker-compose up --exit-code-from adapter && docker-compose down"
+    "mongodb-shell": "docker-compose exec mongo mongo",
+    "docker-test": "docker-compose run adapter bash -c \"npm test\" && docker-compose down"
   },
   "keywords": [
     "mongo",
@@ -27,20 +30,20 @@
     "url": "git://github.com/balderdashy/sails-mongo.git"
   },
   "dependencies": {
-    "@sailshq/lodash": "^3.10.2",
-    "async": "2.0.1",
-    "flaverr": "1.1.1",
-    "machine": "^15.0.0",
+    "@sailshq/lodash": "^3.10.4",
+    "async": "3.2.0",
+    "flaverr": "^1.10.0",
+    "machine": "^15.2.2",
     "mongodb": "2.2.25",
-    "qs": "6.4.0"
+    "qs": "6.9.4"
   },
   "devDependencies": {
-    "benchmark": "2.1.1",
+    "benchmark": "2.1.4",
     "eslint": "4.19.1",
     "mocha": "3.0.2",
-    "waterline": "^0.13.4",
+    "waterline": "^0.13.6",
     "waterline-adapter-tests": "^1.0.1",
-    "waterline-utils": "^1.3.25"
+    "waterline-utils": "^1.4.2"
   },
   "waterlineAdapter": {
     "interfaces": [

--- a/scripts/appveyor/install_mongodb.ps1
+++ b/scripts/appveyor/install_mongodb.ps1
@@ -1,0 +1,20 @@
+# Example. Not yet being used
+$msiPath = "$($env:USERPROFILE)\mongodb-win32-x86_64-2008plus-ssl-3.0.4-signed.msi"
+(New-Object Net.WebClient).DownloadFile('https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-3.0.4-signed.msi', $msiPath)
+cmd /c start /wait msiexec /q /i $msiPath INSTALLLOCATION=C:\mongodb ADDLOCAL="all"
+del $msiPath
+
+mkdir c:\mongodb\data\db | Out-Null
+mkdir c:\mongodb\log | Out-Null
+
+'systemLog:
+    destination: file
+    path: c:\mongodb\log\mongod.log
+storage:
+    dbPath: c:\mongodb\data\db' | Out-File C:\mongodb\mongod.cfg -Encoding utf8
+
+cmd /c start /wait sc create MongoDB binPath= "C:\mongodb\bin\mongod.exe --service --config=C:\mongodb\mongod.cfg" DisplayName= "MongoDB" start= "demand"
+
+& c:\mongodb\bin\mongod --version
+
+Start-Service mongodb

--- a/scripts/travis/install_mongodb.sh
+++ b/scripts/travis/install_mongodb.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+MDB_TGZ=mongodb-linux-x86_64-ubuntu1604-${MONGODB}.tgz
+MDB_ROOT=${TRAVIS_BUILD_DIR}/mongodb/${MONGODB}
+MDB_DATA=${TRAVIS_BUILD_DIR}/mongodb-data
+
+# If it doesn't exist, it means the cache didn't pull it
+if [ ! -f "${MDB_ROOT}/bin/mongod" ]; then
+  mkdir -p $MDB_ROOT
+  pushd $MDB_ROOT
+  wget https://fastdl.mongodb.org/linux/${MDB_TGZ}
+  tar xzf ${MDB_TGZ} --strip 1
+  rm -f ${MDB_TGZ}
+  popd
+fi
+mkdir -p $MDB_DATA
+"${MDB_ROOT}/bin/mongod" --version

--- a/scripts/travis/run_mongodb.sh
+++ b/scripts/travis/run_mongodb.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+MDB_ROOT=${TRAVIS_BUILD_DIR}/mongodb/${MONGODB}
+MDB_DATA=${TRAVIS_BUILD_DIR}/mongodb-data
+
+${MDB_ROOT}/bin/mongod --dbpath ${MDB_DATA} --logpath=/dev/null --fork

--- a/test/connectable/create-manager.test.js
+++ b/test/connectable/create-manager.test.js
@@ -5,7 +5,7 @@ describe('Connectable ::', function() {
   describe('Create Manager', function() {
     it('should work without a protocol in the connection string', function(done) {
       createManager({
-        connectionString: 'localhost:27017/mppg'
+        connectionString: process.env.WATERLINE_ADAPTER_TESTS_URL || 'localhost:27017/mppg'
       })
       .exec(function(err) {
         if (err) {
@@ -31,7 +31,7 @@ describe('Connectable ::', function() {
 
     it('should successfully return a Mongo Server instance', function(done) {
       // Needed to dynamically get the host using the docker container
-      var host = process.env.MONGO_1_PORT_27017_TCP_ADDR || 'localhost';
+      var host = process.env.WATERLINE_ADAPTER_TESTS_HOST || 'localhost';
 
       createManager({
         connectionString: 'mongodb://' + host + ':27017/mppg'

--- a/test/connectable/destroy-manager.test.js
+++ b/test/connectable/destroy-manager.test.js
@@ -8,7 +8,7 @@ describe('Connectable ::', function() {
     // Create a manager
     before(function(done) {
       // Needed to dynamically get the host using the docker container
-      var host = process.env.MONGO_1_PORT_27017_TCP_ADDR || 'localhost';
+      var host = process.env.WATERLINE_ADAPTER_TESTS_HOST || 'localhost';
 
       createManager({
         connectionString: 'mongodb://' + host + ':27017/mppg'

--- a/test/connectable/get-connection.test.js
+++ b/test/connectable/get-connection.test.js
@@ -9,7 +9,7 @@ describe('Connectable ::', function() {
     // Create a manager
     before(function(done) {
       // Needed to dynamically get the host using the docker container
-      var host = process.env.MONGO_1_PORT_27017_TCP_ADDR || 'localhost';
+      var host = process.env.WATERLINE_ADAPTER_TESTS_HOST || 'localhost';
 
       createManager({
         connectionString: 'mongodb://' + host + ':27017/mppg'

--- a/test/connectable/release-connection.test.js
+++ b/test/connectable/release-connection.test.js
@@ -10,7 +10,7 @@ describe('Connectable ::', function() {
     // Create a manager and connection
     before(function(done) {
       // Needed to dynamically get the host using the docker container
-      var host = process.env.MONGO_1_PORT_27017_TCP_ADDR || 'localhost';
+      var host = process.env.WATERLINE_ADAPTER_TESTS_HOST || 'localhost';
 
       createManager({
         connectionString: 'mongodb://' + host + ':27017/mppg'

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--timeout 5000
+--bail

--- a/test/run-standard-tests.js
+++ b/test/run-standard-tests.js
@@ -37,9 +37,9 @@ try {
 
 // Log an intro message.
 console.log('Testing `' + packageMD.name + '`, a Sails/Waterline adapter.');
-console.log('Running `waterline-adapter-tests` against '+packageMD.waterlineAdapter.interfaces.length+' interface(s) and '+packageMD.waterlineAdapter.features.length+' feature(s)...');
-console.log('|   Interfaces:       '+(packageMD.waterlineAdapter.interfaces.join(', ')||'n/a')+'');
-console.log('|   Extra features:   '+((packageMD.waterlineAdapter.features||[]).join(', ')||'n/a')+'');
+console.log('Running `waterline-adapter-tests` against ' + packageMD.waterlineAdapter.interfaces.length + ' interface(s) and ' + packageMD.waterlineAdapter.features.length + ' feature(s)...');
+console.log('|   Interfaces:       ' + (packageMD.waterlineAdapter.interfaces.join(', ') || 'n/a') + '');
+console.log('|   Extra features:   ' + ((packageMD.waterlineAdapter.features || []).join(', ') || 'n/a') + '');
 console.log();
 console.log('> More info about building Waterline adapters:');
 console.log('> http://sailsjs.com/docs/concepts/extending-sails/adapters/custom-adapters');
@@ -48,17 +48,16 @@ console.log('> http://sailsjs.com/docs/concepts/extending-sails/adapters/custom-
 // Ensure a `url` was specified.
 // (http://sailsjs.com/config/datastores#?the-connection-url)
 if (!process.env.WATERLINE_ADAPTER_TESTS_URL) {
-  console.error();
-  console.error('-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-');
-  console.error('Cannot run tests: No database connection `url` specified.');
-  console.error();
-  console.error('Tip: You can use an environment variable to configure this.');
-  console.error('For example:');
-  console.error('```');
-  console.error('    WATERLINE_ADAPTER_TESTS_URL=root@localhost/testdb npm test');
-  console.error('```');
-  console.error('-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-');
-  process.exit(1);
+  console.warn();
+  console.warn('-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-');
+  console.warn('Running using default test MongoDB url: mongo://localhost/testdb');
+  console.warn();
+  console.warn('Tip: You can use an environment variable to configure this.');
+  console.warn('For example:');
+  console.warn('```');
+  console.warn('    WATERLINE_ADAPTER_TESTS_URL=root@localhost/testdb npm test');
+  console.warn('```');
+  console.warn('-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-');
 }//-•
 
 
@@ -72,7 +71,7 @@ new TestRunner({
 
   // Adapter config to use for tests.
   config: {
-    url: process.env.WATERLINE_ADAPTER_TESTS_URL,
+    url: process.env.WATERLINE_ADAPTER_TESTS_URL || 'localhost/testdb'
   },
 
   // The set of adapter interface layers & specific features to test against.
@@ -83,7 +82,7 @@ new TestRunner({
   mocha: {
     bail: true,
     reporter: 'spec'
-  },
+  }
 
 });
 


### PR DESCRIPTION
The idea here is to make sure the testing environment has the latest current and supported versions of Node and MongoDB.

With this, we can better review and clean up the other PRs associated to MongoDB driver upgrades.

My original PR (https://github.com/balderdashy/sails-mongo/pull/480) includes these changes. My intention is to separate that PR into two. This one should be addressed first.

Once this is done, the driver upgrade review would be easier.

My plan is to include/review all the driver PRs that have been proposed and create one based of them:
- https://github.com/balderdashy/sails-mongo/pull/483
- https://github.com/balderdashy/sails-mongo/pull/480
- https://github.com/balderdashy/sails-mongo/pull/472
- https://github.com/balderdashy/sails-mongo/pull/468

I'd appreciate the eyes of @mikermcneil, @Josebaseba 

* [ENHANCEMENT] Adds `npm run start-mongodb` and `npm run stop-mongodb` scripts to start/stop a MongoDB docker instance

* [ENHANCEMENT] Adds `npm run mongodb-shell` to run a MongoDB Shell CLI that connects to the MongoDB docker instance
* [INTERNAL] Bump and pin dependency versions
* [INTERNAL] Tests in Travis run against a combination of Node.js 10, 12, 14 and MongoDB: 3.6, 4.0, 4.2
* [INTERNAL] Refactors docker-compose.yml, removing the need of Dockerfile. Updates Docker node version to 12, and MongoDB to 4.2
