### PR TITLE
[proposal] bump mongodb dependency to resolve npm audit warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "async": "3.2.0",
     "flaverr": "^1.10.0",
     "machine": "^15.2.2",
-    "mongodb": "2.2.25",
+    "mongodb": "3.6.2",
     "qs": "6.9.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Current output from `npm audit` shows:
```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Denial of Service                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ mongodb                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=3.1.13                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ sails-mongo                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ sails-mongo > mongodb                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1203                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

Mongo fixed the issue in 3..1.13, 3.6.2 is their current latest