### PR TITLE
[patch] fix standard adapter tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib",
   "scripts": {
     "test": "npm run lint && npm run custom-tests",
-    "custom-tests": "node node_modules/mocha/bin/mocha test/run-adapter-specific-tests && node node_modules/mocha/bin/mocha test/connectable/ && node node_modules/mocha/bin/mocha test/run-standard-tests",
+    "custom-tests": "node node_modules/mocha/bin/mocha test/run-adapter-specific-tests && node node_modules/mocha/bin/mocha test/connectable/ && node test/run-standard-tests",
     "lint": "node node_modules/eslint/bin/eslint . --max-warnings=0",
     "start-mongodb": "docker-compose up -d mongo",
     "stop-mongodb": "docker-compose down",


### PR DESCRIPTION
This fixes the standard adapter tests being skipped in the `custom-tests` script