### PR TITLE
Update async 3.2.4, mongodb 3.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "@sailshq/lodash": "^3.10.4",
-    "async": "3.2.0",
+    "async": "3.2.4",
     "flaverr": "^1.10.0",
     "machine": "^15.2.2",
-    "mongodb": "3.5.9",
+    "mongodb": "3.7.3",
     "qs": "6.9.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Update async to fix npm audit issue

```
# npm audit report

async  3.0.0 - 3.2.1
Severity: high
Prototype Pollution in async - https://github.com/advisories/GHSA-fwr7-v2mv-hh25
fix available via `npm audit fix --force`
Will install sails-mongo@1.2.0, which is a breaking change
node_modules/sails-mongo/node_modules/async
  sails-mongo  >=2.0.0-0
  Depends on vulnerable versions of async
  node_modules/sails-mongo
```

Update MongoDB driver to 3.x.y latest with the same [compatibility](https://www.mongodb.com/docs/drivers/node/v3.7/compatibility/) for legacy MongoDB but also with better support for newer versions